### PR TITLE
chore: Better error message in new command.

### DIFF
--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -26,7 +26,7 @@ class NewCommand(Command):
             if list(path.glob('*')):
                 # Directory is not empty. Aborting.
                 raise RuntimeError(
-                    'Destination <fg=yellow;bg=red>{}</>'
+                    'Destination <fg=yellow;bg=red>{}</> '
                     'exists and is not empty'.format(
                         path
                     )


### PR DESCRIPTION
Update error message for existed directory in `new` command: add a space after directory path,

## Before

```
octave:path playpauseandstop$ poetry new .

                                                                                 
  [RuntimeError]                                                                 
  Destination /Users/playpauseandstop/Projects/pathexists and is not empty  
                                                                                 

new [--name] [--] <path>
```

## After

```
octave:path playpauseandstop$ poetry new .

                                                                                 
  [RuntimeError]                                                                 
  Destination /Users/playpauseandstop/Projects/path exists and is not empty  
                                                                                 

new [--name] [--] <path>
```