### PR TITLE
WIP : Change python version at install

### DIFF
--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -10,6 +10,7 @@ class InstallCommand(VenvCommand):
         { --dry-run : Outputs the operations but will not execute anything
                       (implicitly enables --verbose). }
         { --E|extras=* : Extra sets of dependencies to install. }
+        { --python=* : Python version used to create virtualenv. ex :  2.7, 3.5 }
     """
 
     help = """The <info>install</info> command reads the <comment>pyproject.toml</> file from

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -10,9 +10,8 @@ class InstallCommand(VenvCommand):
         { --dry-run : Outputs the operations but will not execute anything
                       (implicitly enables --verbose). }
         { --E|extras=* : Extra sets of dependencies to install. }
-        { --python=* : Python version used to create virtualenv. ex :  2.7, 3.5 }
+        { --python=* : Python version used to create virtualenv. ex 2.7, 3.5 }
     """
-
     help = """The <info>install</info> command reads the <comment>pyproject.toml</> file from
 the current directory, processes it, and downloads and installs all the
 libraries and dependencies outlined in that file. If the file does not

--- a/poetry/console/commands/venv_command.py
+++ b/poetry/console/commands/venv_command.py
@@ -13,7 +13,10 @@ class VenvCommand(Command):
 
         super(VenvCommand, self).initialize(i, o)
 
-        self._venv = Venv.create(o, self.poetry.package.name)
+        py_version = self.input.options.get('python', None)
+        py_version = py_version[0] if py_version else None
+
+        self._venv = Venv.create(io=o, name=self.poetry.package.name, py_version=py_version)
 
         if self._venv.is_venv() and o.is_verbose():
             o.writeln(

--- a/poetry/utils/venv.py
+++ b/poetry/utils/venv.py
@@ -65,10 +65,17 @@ class Venv(object):
             # set py_version to poetry's python version by default
             py_version = py_version if py_version else sys.version[:3]
 
-            name = '{}-py{}'.format(
-                name, py_version)
+            # name = '{}-py{}'.format(
+            #     name, py_version)
 
             venv = venv_path / name
+
+            import hashlib
+
+            name =  name + '-'+ hashlib.md5(str(venv).encode()).hexdigest()
+
+            venv = venv_path / name
+
             if not venv.exists():
                 if create_venv is False:
                     io.writeln(
@@ -84,7 +91,7 @@ class Venv(object):
                         name, str(venv_path)
                     )
                 )
-                cls.build(str(venv))
+                cls.build(str(venv), py_version)
             else:
                 if io.is_very_verbose():
                     io.writeln(

--- a/poetry/utils/venv.py
+++ b/poetry/utils/venv.py
@@ -65,14 +65,12 @@ class Venv(object):
             # set py_version to poetry's python version by default
             py_version = py_version if py_version else sys.version[:3]
 
-            # name = '{}-py{}'.format(
-            #     name, py_version)
 
             venv = venv_path / name
 
             import hashlib
-
-            name =  name + '-'+ hashlib.md5(str(venv).encode()).hexdigest()
+            
+            name =  name + '-'+ hashlib.md5(str(Path.cwd()).encode()).hexdigest()
 
             venv = venv_path / name
 

--- a/tests/utils/test_venv.py
+++ b/tests/utils/test_venv.py
@@ -1,0 +1,75 @@
+import pytest
+
+from poetry.utils.venv import Venv, VenvError, VenvError
+import sys
+import os
+from unittest.mock import MagicMock
+from poetry.utils._compat import Path
+
+
+"""
+create :    change name
+            pyversion
+
+"""
+global pp_arg
+
+
+def test_create_set_venv_name_with_name(monkeypatch, tmpdir):
+    monkeypatch.delenv('VIRTUAL_ENV')
+    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+    monkeypatch.setattr('poetry.utils.venv.Path', lambda x: tmpdir)
+    a = Venv.create(io = MagicMock(), name="rien", py_version="2.7")
+    assert os.environ['VIRTUAL_ENV'] == str(tmpdir.join("virtualenvs","rien-py2.7"))
+
+def test_create_set_venv_name_without_name(monkeypatch, tmpdir):
+    monkeypatch.delenv('VIRTUAL_ENV')
+    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+
+    path = MagicMock(return_value=Path(str(tmpdir)))
+    mm = MagicMock()
+    mm.name = "essai"
+    path.cwd.return_value = mm
+    monkeypatch.setattr('poetry.utils.venv.Path', path)
+
+    a = Venv.create(io = MagicMock(), py_version="2.7")
+    assert os.environ['VIRTUAL_ENV'] == str(tmpdir.join("virtualenvs","essai-py2.7"))
+
+def test_create_set_venv_name_without_pyversion(monkeypatch, tmpdir):
+    monkeypatch.delenv('VIRTUAL_ENV')
+    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+    monkeypatch.setattr('poetry.utils.venv.Path', lambda x: tmpdir)
+    a = Venv.create(io = MagicMock(), name="rien")
+    vv = sys.version[:3]
+    assert os.environ['VIRTUAL_ENV'] == str(tmpdir.join("virtualenvs","rien-py"+vv))
+
+def test_popen_args(tmpdir, monkeypatch):
+    path = tmpdir.join("myenv")
+    def mock(self):
+        # argg
+        global pp_arg
+        self.kill()
+        pp_arg =  self.args
+        return (1,2)
+
+    monkeypatch.setattr("poetry.utils.venv.Popen.communicate", mock)
+    Venv.build(str(path))
+    assert pp_arg[0] == 'python'+sys.version[:3]
+
+    Venv.build(str(path), py_version='3.6')
+    assert pp_arg == ['python3.6', '-m', 'venv', str(path)]
+
+    Venv.build(str(path), py_version='2.7')
+    assert pp_arg == ['python2.7', '-m', 'virtualenv', str(path)]
+
+@pytest.mark.skipif(sys.version_info < (3,),reason="requires python3")
+def test_python3_version_error(tmpdir):
+    with pytest.raises(VenvError) as exc:
+        Venv.build(str(tmpdir), py_version='2.10')
+    assert str(exc.value) == 'Python version : 2.10 seems no to be installed on the system'
+
+@pytest.mark.skipif(sys.version_info >= (3,),reason="requires python2.7")
+def test_python2_version_error(tmpdir):
+    with pytest.raises(VenvError) as exc:
+        Venv.build(str(tmpdir), py_version='2.10')
+    assert str(exc.value) == 'Python version : 2.10 seems no to be installed on the system'

--- a/tests/utils/test_venv.py
+++ b/tests/utils/test_venv.py
@@ -17,14 +17,14 @@ global pp_arg
 
 def test_create_set_venv_name_with_name(monkeypatch, tmpdir):
     monkeypatch.delenv('VIRTUAL_ENV')
-    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+    monkeypatch.setattr(Venv, 'build', lambda x,y: "rien")
     monkeypatch.setattr('poetry.utils.venv.Path', lambda x: tmpdir)
     a = Venv.create(io = MagicMock(), name="rien", py_version="2.7")
     assert os.environ['VIRTUAL_ENV'] == str(tmpdir.join("virtualenvs","rien-py2.7"))
 
 def test_create_set_venv_name_without_name(monkeypatch, tmpdir):
     monkeypatch.delenv('VIRTUAL_ENV')
-    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+    monkeypatch.setattr(Venv, 'build', lambda x,y: "rien")
 
     path = MagicMock(return_value=Path(str(tmpdir)))
     mm = MagicMock()
@@ -37,7 +37,7 @@ def test_create_set_venv_name_without_name(monkeypatch, tmpdir):
 
 def test_create_set_venv_name_without_pyversion(monkeypatch, tmpdir):
     monkeypatch.delenv('VIRTUAL_ENV')
-    monkeypatch.setattr(Venv, 'build', lambda x: "rien")
+    monkeypatch.setattr(Venv, 'build', lambda x,y: "rien")
     monkeypatch.setattr('poetry.utils.venv.Path', lambda x: tmpdir)
     a = Venv.create(io = MagicMock(), name="rien")
     vv = sys.version[:3]


### PR DESCRIPTION
This PR is  related to #77 

you can choose your python version:
`poetry install --python 3.6`

It will install the asked python version if present on the system.

Doing this I have to change the virtualenv name to make poetry know where to search.
The new name is project name + a md5 calculated from the path of the project
`/path/to/virtualenv/myproject-fzef84z38ef4ze8f4z3e`
So the venv can always be found if the project's path doesn't change.

Tests are not yet fully ok.

this doesn't solve the problemeof consistency between the created venv and  the python version needed in the pyproject.toml