### PR TITLE
evaluate "path" dependencies as relative to the pyproject.toml, not to the CWD

### DIFF
--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -110,6 +110,7 @@ class Package(object):
         self._platform_constraint = EmptyConstraint()
 
         self.cwd = None
+        self.root_dir = None
 
     @property
     def name(self):
@@ -303,7 +304,7 @@ class Package(object):
                         path,
                         category=category,
                         optional=optional,
-                        base=self.cwd,
+                        base=self.root_dir,
                         develop=constraint.get('develop', False)
                     )
             else:

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -109,7 +109,6 @@ class Package(object):
         self._platform = '*'
         self._platform_constraint = EmptyConstraint()
 
-        self.cwd = None
         self.root_dir = None
 
     @property
@@ -282,13 +281,13 @@ class Package(object):
                 dependency = FileDependency(
                     file_path,
                     category=category,
-                    base=self.cwd
+                    base=self.root_dir
                 )
             elif 'path' in constraint:
                 path = Path(constraint['path'])
 
-                if self.cwd:
-                    is_file = (self.cwd / path).is_file()
+                if self.root_dir:
+                    is_file = (self.root_dir / path).is_file()
                 else:
                     is_file = path.is_file()
 
@@ -297,7 +296,7 @@ class Package(object):
                         path,
                         category=category,
                         optional=optional,
-                        base=self.cwd
+                        base=self.root_dir
                     )
                 else:
                     dependency = DirectoryDependency(

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -96,7 +96,6 @@ class Poetry:
         name = local_config['name']
         version = local_config['version']
         package = Package(name, version, version)
-        package.cwd = Path(cwd)
         package.root_dir = poetry_file.parent
 
         for author in local_config['authors']:
@@ -110,7 +109,7 @@ class Poetry:
         package.classifiers = local_config.get('classifiers', [])
 
         if 'readme' in local_config:
-            package.readme = Path(cwd) / local_config['readme']
+            package.readme = Path(poetry_file.parent) / local_config['readme']
 
         if 'platform' in local_config:
             package.platform = local_config['platform']

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -97,6 +97,7 @@ class Poetry:
         version = local_config['version']
         package = Package(name, version, version)
         package.cwd = Path(cwd)
+        package.root_dir = poetry_file.parent
 
         for author in local_config['authors']:
             package.authors.append(author)


### PR DESCRIPTION
poetry recently added support for searching upwards in the directory hierarchy for `pyproject.toml`. However, this wasn't playing well with the `path` dependency type when the dependency had a relative directory. This PR makes it evaluate `path` dependencies relative to the pyproject.toml instead of the CWD.