### PR TITLE
Update the _canonicalize_regex to no longer modify periods

### DIFF
--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -5,7 +5,7 @@ import tempfile
 from contextlib import contextmanager
 from typing import Union
 
-_canonicalize_regex = re.compile('[-_.]+')
+_canonicalize_regex = re.compile('[-_]+')
 
 
 def canonicalize_name(name):  # type: (str) -> str
@@ -13,7 +13,7 @@ def canonicalize_name(name):  # type: (str) -> str
 
 
 def module_name(name):  # type: (str) -> str
-    return canonicalize_name(name).replace('-', '_')
+    return canonicalize_name(name).replace('.', '_').replace('-', '_')
 
 
 @contextmanager


### PR DESCRIPTION
This also updates the `module_name` helper function so that it still
replaces periods with underscores as it did previously.

No tests have started failing, so I am not sure if this was tested or not.

---

Closes https://github.com/sdispater/poetry/issues/109