### PR TITLE
Fix installation permissions

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -287,6 +287,7 @@ class Installer:
                 "install",
                 "--upgrade",
                 "--no-deps",
+                '--user',
                 os.path.join(dir, "poetry-{}-{}.whl".format(version, tag)),
             )
 

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -287,7 +287,7 @@ class Installer:
                 "install",
                 "--upgrade",
                 "--no-deps",
-                '--user',
+                "--user",
                 os.path.join(dir, "poetry-{}-{}.whl".format(version, tag)),
             )
 


### PR DESCRIPTION
Avoid having to use superuser (administrator) privileges for platforms where the global pip installation directory is not writable by the regular user.

Se `pip help install | grep -A 4 -e '--user'`:
```
  --user                      Install to the Python user install directory for
                              your platform. Typically ~/.local/, or
                              %APPDATA%\Python on Windows. (See the Python
                              documentation for site.USER_BASE for full
                              details.)
```
Docs for [site.USER_BASE](https://docs.python.org/3.7/library/site.html#site.USER_BASE).

Fixes:
- #59 

Open questions:

- [ ] Should this be optional? If so, should it be opt-in, or opt-out?
- [ ] Should we prompt the user that the user install directory (`site.USER_BASE`) needs to be in the `$PATH` / `%PATH%` variable in order for `poetry` to be recognized as a command?