### PR TITLE
Catch ValueErrors when iterating of repositories (#189)

### DIFF
--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -79,11 +79,14 @@ class Pool(BaseRepository):
         self, name, constraint=None, extras=None, allow_prereleases=False
     ):
         for repository in self._repositories:
-            packages = repository.find_packages(
-                name, constraint, extras=extras, allow_prereleases=allow_prereleases
-            )
-            if packages:
-                return packages
+            try:
+                packages = repository.find_packages(
+                    name, constraint, extras=extras, allow_prereleases=allow_prereleases
+                )
+                if packages:
+                    return packages
+            except ValueError:
+                pass
 
         return []
 


### PR DESCRIPTION
This might not be the best way to do it, but at least I tried and fixed #189. :-)

Some tests (`poetry run pytest`) are not passing, but it's apparently due to my system:

    OSError: [Errno 16] Device or resource busy: '.nfs000000000008751500000052'