### PR TITLE
Add `readme` to poetry schema required key

### DIFF
--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -6,7 +6,8 @@
     "required": [
         "name",
         "version",
-        "description"
+        "description",
+        "readme"
     ],
     "properties": {
         "name": {


### PR DESCRIPTION
Make readme key truly required as stated in the docs

Closes #237 