### PR TITLE
fix exception message in package_include

### DIFF
--- a/poetry/masonry/utils/package_include.py
+++ b/poetry/masonry/utils/package_include.py
@@ -36,7 +36,9 @@ class PackageInclude(Include):
 
     def check_elements(self):  # type: () -> PackageInclude
         if not self._elements:
-            raise ValueError("{} does not contain any element".format(self._base / self._include))
+            raise ValueError(
+                "{} does not contain any element".format(self._base / self._include)
+            )
 
         if len(self._elements) > 1:
             # Probably glob

--- a/poetry/masonry/utils/package_include.py
+++ b/poetry/masonry/utils/package_include.py
@@ -36,7 +36,7 @@ class PackageInclude(Include):
 
     def check_elements(self):  # type: () -> PackageInclude
         if not self._elements:
-            raise ValueError("{} does not contain any element".format(base / include))
+            raise ValueError("{} does not contain any element".format(self._base / self._include))
 
         if len(self._elements) > 1:
             # Probably glob


### PR DESCRIPTION
Fixes an exception message in `package_include.py` by inserting the correct variables.

Bug was encountered in https://github.com/sdispater/poetry/issues/254