### PR TITLE
Fix broken json schema preventing DirectoryDependency to be added

### DIFF
--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -140,6 +140,9 @@
                         },
                         {
                             "$ref": "#/definitions/file-dependency"
+                        },
+                        {
+                            "$ref": "#/definitions/path-dependency"
                         }
                     ]
                 }

--- a/tests/json/test_dependencies.py
+++ b/tests/json/test_dependencies.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+import pytest
+import jsonschema
+
+
+PACKAGE_ROOT = Path(__file__).parent.parent.parent / "poetry"
+MIN_CONFIG = {"name": "", "version": "", "description": ""}
+
+
+@pytest.fixture
+def schema():
+    schema = PACKAGE_ROOT / "json" / "schemas" / "poetry-schema.json"
+    with schema.open() as f:
+        schema = json.loads(f.read())
+    return schema
+
+
+@pytest.mark.parametrize(
+    "dependencies,expectation",
+    [
+        ({"dependencies": {"python": "", "a": {"path": "../b"}}}),
+        ({"dev-dependencies": {"a": {"path": "../b"}}}),
+    ],
+)
+def test_path_deps(dependencies, expectation, schema):
+    config = {**MIN_CONFIG, **dependencies}
+    # validate() either returns None(valid) or raises(invalid config or schema)
+    assert jsonschema.validate(config, schema) is None


### PR DESCRIPTION
Trying to add deps with both `--path` and `--dev` was raising:

`jsonschema.exceptions.ValidationError: {'path': '../some'} is not valid under any of the given schemas`

Seems the schema definitions for dependencies & dev-dependencies have diverged, so this little PR fixes the above error.
However, even with this PR, there's eg the `python` property missing in dev-deps - should both properties rather point an abstract definition, DRY style?