### PR TITLE
Add env command

### DIFF
--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -19,6 +19,7 @@ from .commands import BuildCommand
 from .commands import CheckCommand
 from .commands import ConfigCommand
 from .commands import DevelopCommand
+from .commands import EnvCommand
 from .commands import InitCommand
 from .commands import InstallCommand
 from .commands import LockCommand
@@ -111,6 +112,7 @@ class Application(BaseApplication):
             CheckCommand(),
             ConfigCommand(),
             DevelopCommand(),
+            EnvCommand(),
             InitCommand(),
             InstallCommand(),
             LockCommand(),

--- a/poetry/console/commands/__init__.py
+++ b/poetry/console/commands/__init__.py
@@ -4,6 +4,7 @@ from .build import BuildCommand
 from .check import CheckCommand
 from .config import ConfigCommand
 from .develop import DevelopCommand
+from .env import EnvCommand
 from .init import InitCommand
 from .install import InstallCommand
 from .lock import LockCommand

--- a/poetry/console/commands/env.py
+++ b/poetry/console/commands/env.py
@@ -10,7 +10,7 @@ class EnvCommand(VenvCommand):
         { --p|path : Show the path to virtual environment. }
         { --python : Show the path to the python executable. }
         { --pip : Show the path to the pip executable. }
-        { --r|remove : Remove the virtual environment. }
+        { --rm : Remove the virtual environment. }
     """
 
     help = """The env command displays information about the virtual environment.
@@ -28,7 +28,7 @@ If it doesn't exist when the command is ran, it will be created."""
         elif self.option("pip"):
             self.info(self.venv.pip)
 
-        elif self.option("remove"):
+        elif self.option("rm"):
             self.line("Removing virtual environment at <info>{}</>".format(path))
             rmtree(path, ignore_errors=True)
 

--- a/poetry/console/commands/env.py
+++ b/poetry/console/commands/env.py
@@ -1,0 +1,40 @@
+from .venv_command import VenvCommand
+from shutil import rmtree
+
+
+class EnvCommand(VenvCommand):
+    """
+    Shows information about the virtual environment.
+    If it doesn't exist when the command is ran, it will be created.
+
+    env
+        { --p|path : Show the path to virtual environment. }
+        { --python : Show the path to the python executable. }
+        { --pip : Show the path to the pip executable. }
+        { --r|remove : Remove the virtual environment. }
+    """
+
+    help = """The env command displays information about the virtual environment."""
+
+    def handle(self):
+        path = self.venv.venv
+
+        if self.option("path"):
+            self.info(path)
+
+        elif self.option("python"):
+            self.info(self.venv.python)
+
+        elif self.option("pip"):
+            self.info(self.venv.pip)
+
+        elif self.option("remove"):
+            self.line("Removing virtual environment at <info>{}</>".format(path))
+            rmtree(path, ignore_errors=True)
+
+        else:
+            version = ".".join(str(s) for s in self.venv.version_info[:3])
+            impl = self.venv.python_implementation
+            self.line("<info>Virtualenv path</>: <comment>{}</>".format(path))
+            self.line("<info>Python version</>: <comment>{}</>".format(version))
+            self.line("<info>Implementation</>: <comment>{}</>".format(impl))

--- a/poetry/console/commands/env.py
+++ b/poetry/console/commands/env.py
@@ -5,7 +5,6 @@ from shutil import rmtree
 class EnvCommand(VenvCommand):
     """
     Shows information about the virtual environment.
-    If it doesn't exist when the command is ran, it will be created.
 
     env
         { --p|path : Show the path to virtual environment. }
@@ -14,7 +13,8 @@ class EnvCommand(VenvCommand):
         { --r|remove : Remove the virtual environment. }
     """
 
-    help = """The env command displays information about the virtual environment."""
+    help = """The env command displays information about the virtual environment.
+If it doesn't exist when the command is ran, it will be created."""
 
     def handle(self):
         path = self.venv.venv


### PR DESCRIPTION
To satisfy the needs expressed in #270 (and, to some extent, #198), I added an `env` command.
```
~/foo $ pt env
Virtualenv path: /home/cauebs/foo/.venv
Python version: 3.6.5
Implementation: CPython

~/foo $ pt env --python
/home/cauebs/foo/.venv/bin/python

~/foo $ pt env --pip
/home/cauebs/foo/.venv/bin/pip

~/foo $ pt env --path
/home/cauebs/foo/.venv

~/foo $ pt env --rm
Removing virtual environment at /home/cauebs/foo/.venv
```

If this gets a greenlight, I'll add tests and docs.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.