### PR TITLE
update libraries documentation to reflect `publish` default behavior

### DIFF
--- a/docs/docs/libraries.md
+++ b/docs/docs/libraries.md
@@ -46,7 +46,7 @@ Poetry will publish to [PyPI](https://pypi.org) by default. Anything that is pub
 is available automatically through Poetry. Since [pendulum](https://pypi.org/project/pendulum/)
 is on PyPI we can depend on it without having to specify any additional repositories.
 
-If we wanted to share `poetry-demo` with the Python community, we would publish on PyPI as weel.
+If we wanted to share `poetry-demo` with the Python community, we would publish on PyPI as well.
 Doing so is really easy.
 
 ```bash
@@ -58,10 +58,10 @@ and you have [configured your credentials](/repositories/#adding-credentials) pr
 
 !!!note
 
-    The `publish` command also executes `build` by default.
+    The `publish` command does not execute `build` by default.
     
-    If you want to build your packages separately and later publish them,
-    just pass the `--no-build` option.
+    If you want to build and publish your packages together,
+    just pass the `--build` option.
     
 Once this is done, your library will be available to anyone.
 


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

# Description

While reading the libraries documentation I noticed that it says that building was the default, which I believe is incorrect. A quick look at the code confirms it. https://github.com/sdispater/poetry/blob/af8f86cda703144e9261b700d3165433aa2d3603/poetry/console/commands/publish.py#L29-L40

This PR corrects that bit of the documentation.