### PR TITLE
point to the run command in the script command's help

### DIFF
--- a/poetry/console/commands/script.py
+++ b/poetry/console/commands/script.py
@@ -10,6 +10,9 @@ class ScriptCommand(VenvCommand):
         { args?* : The command and arguments/options to pass to the script. }
     """
 
+    help = """The <info>script</> command is deprecated. Please use <info>run</info> instead.
+    """
+
     def handle(self):
         self.line("<warning>script is deprecated use run instead.</warning>")
         self.line("")


### PR DESCRIPTION
don't let the user wonder what command to use - just point it to him