### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -215,5 +215,5 @@ To match the example in the setuptools documentation, you would use the followin
 [tool.poetry.plugins] # Optional super table
 
 [tool.poetry.plugins."blogtool.parsers"]
-".rst" = "some_module::SomeClass"
+".rst" = "some_module:SomeClass"
 ```


### PR DESCRIPTION
Seems like there is typo in one of the examples. After eliminating the extra colon, I was able to build and install the package correctly.