### PR TITLE
Adding support for HTTP Basic Auth when installing and searching from legacy repo (#233)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ MANIFEST.in
 pyproject.lock
 /tests/fixtures/simple_project/setup.py
 .mypy_cache
+
+.venv

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -63,3 +63,8 @@ url = "https://foo.bar/simple/"
 ```
 
 From now on, Poetry will also look for packages in your private repository.
+
+If your private repository requires HTTP Basic Auth be sure to add the username and
+password to your `http-basic` config using the example above (be sure to use the
+same name than in the `tool.poetry.source` section). Poetry will use these values
+to authenticate to your private repository when downloading or looking for packages.

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -25,9 +25,14 @@ class PipInstaller(BaseInstaller):
         if package.source_type == "legacy" and package.source_url:
             parsed = urlparse.urlparse(package.source_url)
             if parsed.scheme == "http":
+                if not parsed.username:
+                    from_host = parsed.netloc
+                else:
+                    from_host = parsed.netloc[parsed.netloc.index("@") + 1 :]
+
                 self._io.write_error(
                     "    <warning>Installing from unsecure host: {}</warning>".format(
-                        parsed.netloc
+                        from_host
                     )
                 )
                 args += ["--trusted-host", parsed.netloc]

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -35,8 +35,7 @@ class PipInstaller(BaseInstaller):
                 )
                 args += ["--trusted-host", parsed.netloc]
 
-            # This here won't work, need some pointers
-            auth = get_http_basic_auth(package.source_url)
+            auth = get_http_basic_auth(package.source_reference)
             if auth:
                 index_url = "{scheme}://{username}:{password}@{netloc}{path}".format(
                     scheme=parsed.scheme,

--- a/poetry/masonry/publishing/publisher.py
+++ b/poetry/masonry/publishing/publisher.py
@@ -1,5 +1,6 @@
 from poetry.locations import CONFIG_DIR
 from poetry.utils._compat import Path
+from poetry.utils.helpers import get_http_basic_auth
 from poetry.utils.toml_file import TomlFile
 
 from .uploader import Uploader
@@ -64,18 +65,7 @@ class Publisher:
             url = config["repositories"][repository_name]["url"]
 
         if not (username and password):
-            auth_file = TomlFile(Path(CONFIG_DIR) / "auth.toml")
-            if auth_file.exists():
-                auth_config = auth_file.read(raw=True)
-
-                if (
-                    "http-basic" in auth_config
-                    and repository_name in auth_config["http-basic"]
-                ):
-                    config = auth_config["http-basic"][repository_name]
-
-                    username = config.get("username")
-                    password = config.get("password")
+            username, password = get_http_basic_auth(repository_name)
 
         # Requesting missing credentials
         if not username:

--- a/poetry/masonry/publishing/publisher.py
+++ b/poetry/masonry/publishing/publisher.py
@@ -65,7 +65,10 @@ class Publisher:
             url = config["repositories"][repository_name]["url"]
 
         if not (username and password):
-            username, password = get_http_basic_auth(repository_name)
+            auth = get_http_basic_auth(repository_name)
+            if auth:
+                username = auth[0]
+                password = auth[1]
 
         # Requesting missing credentials
         if not username:

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -242,6 +242,7 @@ class LegacyRepository(PyPiRepository):
             package = poetry.packages.Package(name, version, version)
             package.source_type = "legacy"
             package.source_url = self._url
+            package.source_reference = self.name
 
             requires_dist = release_info["requires_dist"] or []
             for req in requires_dist:

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -38,7 +38,7 @@ from poetry.semver import parse_constraint
 from poetry.semver import Version
 from poetry.semver import VersionConstraint
 from poetry.utils._compat import Path
-from poetry.utils.helpers import canonicalize_name
+from poetry.utils.helpers import canonicalize_name, get_http_basic_auth
 from poetry.version.markers import InvalidMarker
 
 from .pypi_repository import PyPiRepository
@@ -162,12 +162,9 @@ class LegacyRepository(PyPiRepository):
 
         url_parts = urlparse.urlparse(self._url)
         if not url_parts.username:
-            config = Config.create("auth.toml")
-            repo_auth = config.setting("http-basic.{}".format(self.name))
-            if repo_auth:
-                netloc = "{}:{}@{}".format(
-                    repo_auth["username"], repo_auth["password"], url_parts.netloc
-                )
+            username, password = get_http_basic_auth(self.name)
+            if username and password:
+                netloc = "{}:{}@{}".format(username, password, url_parts.netloc)
                 self._url = urlparse.urlunsplit(
                     (url_parts.scheme, netloc, url_parts.path, "", "")
                 )

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -5,6 +5,7 @@ import tempfile
 from contextlib import contextmanager
 from typing import Union
 
+from poetry.config import Config
 from poetry.version import Version
 
 _canonicalize_regex = re.compile("[-_]+")
@@ -77,3 +78,11 @@ def parse_requires(requires):  # type: (str) -> Union[list, None]
 
     if requires_dist:
         return requires_dist
+
+
+def get_http_basic_auth(repository_name):  # type: (str) -> (str, str)
+    config = Config.create("auth.toml")
+    repo_auth = config.setting("http-basic.{}".format(repository_name))
+    if repo_auth:
+        return repo_auth["username"], repo_auth["password"]
+    return "", ""

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -80,9 +80,9 @@ def parse_requires(requires):  # type: (str) -> Union[list, None]
         return requires_dist
 
 
-def get_http_basic_auth(repository_name):  # type: (str) -> (str, str)
+def get_http_basic_auth(repository_name):  # type: (str) -> tuple
     config = Config.create("auth.toml")
     repo_auth = config.setting("http-basic.{}".format(repository_name))
     if repo_auth:
         return repo_auth["username"], repo_auth["password"]
-    return "", ""
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ pygments-github-lexers = "^0.0.5"
 black = { version = "^18.3-alpha.0", python = "^3.6" }
 pre-commit = "^1.10"
 tox = "^3.0"
-mock = "^2.0"
 
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pygments-github-lexers = "^0.0.5"
 black = { version = "^18.3-alpha.0", python = "^3.6" }
 pre-commit = "^1.10"
 tox = "^3.0"
+mock = "^2.0"
 
 
 [tool.poetry.scripts]

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -46,13 +46,9 @@ def test_page_absolute_links_path_are_correct():
         assert link.path.startswith("/packages/")
 
 
-@mock.patch("poetry.repositories.legacy_repository.Config")
-def test_http_basic_auth_repo(mock_config):
-    class MockConfig(object):
-        def setting(self, _, **__):
-            return {"username": "user1", "password": "p4ss"}
-
-    mock_config.create = MagicMock(return_value=MockConfig())
+@mock.patch("poetry.repositories.legacy_repository.get_http_basic_auth")
+def test_http_basic_auth_repo(mock_get_auth):
+    mock_get_auth.return_value = ("user1", "p4ss")
 
     repo = MockRepository()
     assert "user1:p4ss@" in repo._url

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import MagicMock, mock
 
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
@@ -43,3 +44,15 @@ def test_page_absolute_links_path_are_correct():
     for link in page.links:
         assert link.netloc == "files.pythonhosted.org"
         assert link.path.startswith("/packages/")
+
+
+@mock.patch("poetry.repositories.legacy_repository.Config")
+def test_http_basic_auth_repo(mock_config):
+    class MockConfig(object):
+        def setting(self, _, **__):
+            return {"username": "user1", "password": "p4ss"}
+
+    mock_config.create = MagicMock(return_value=MockConfig())
+
+    repo = MockRepository()
+    assert "user1:p4ss@" in repo._url

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,10 +1,6 @@
-import pytest
-from mock import MagicMock, mock
-
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
 from poetry.utils._compat import Path
-from poetry.utils._compat import decode
 
 
 class MockRepository(LegacyRepository):
@@ -46,9 +42,11 @@ def test_page_absolute_links_path_are_correct():
         assert link.path.startswith("/packages/")
 
 
-@mock.patch("poetry.repositories.legacy_repository.get_http_basic_auth")
-def test_http_basic_auth_repo(mock_get_auth):
-    mock_get_auth.return_value = ("user1", "p4ss")
+def test_http_basic_auth_repo(mocker):
+    mock = mocker.patch("poetry.repositories.legacy_repository.get_http_basic_auth")
+    mock.return_value = ("user1", "p4ss")
 
     repo = MockRepository()
-    assert "user1:p4ss@" in repo._url
+
+    mock.assert_called_once_with("legacy")
+    assert repo._session.auth == ("user1", "p4ss")


### PR DESCRIPTION
# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

Hi! I really like `poetry` and would love to be able to use it at work, sadly it doesn't support HTTP Basic Auth when pulling from private repositories so that has kept us from using it. See #233 

That is why I have come up with this PR. It basically adds support for pulling from private repos using the auth values stored in `http-basic.<repo-name>` by inserting them in the repo URL dynamically. I've also made sure that the username and password are never output to the shell.

While doing this I tried to have the most minimal impact on existing user. For example, anyone that already defines username and password directly in the URL of the `pyproject.toml` file won't suddenly have issues since I check for existing credentials and skip my code if anything is found (But I suggest those who do this now use the `http-basic` configuration). Additionally, I make sure that if no credentials are found for this specific repo the URL won't be altered at all.

~~I did not write tests yet because I wanted my design validated first and because I am not sure how to approach tests for this feature.~~
I wrote a unit test that mocks reading `http-basic` from the config and uses the returned values to create a new URL and then validates that the URL was properly constructed.
I have also tested the functionality locally using a devpi-server behind a HTTP Basic Auth protected web server, with the config below

`pyproject.toml`:
```toml
[[tool.poetry.source]]
url = "http://localhost:3142/root/pypi/+simple/"
name = "devpi"
```

```bash
poetry config http-basic devpi user pass
```