### PR TITLE
Fix: match legacy URL API documentation

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -185,7 +185,7 @@ class LegacyRepository(PyPiRepository):
         if self._cache.store("matches").has(key):
             versions = self._cache.store("matches").get(key)
         else:
-            page = self._get("/{}".format(canonicalize_name(name).replace(".", "-")))
+            page = self._get("/{}/".format(canonicalize_name(name).replace(".", "-")))
             if page is None:
                 return []
 
@@ -284,7 +284,7 @@ class LegacyRepository(PyPiRepository):
             return package
 
     def _get_release_info(self, name, version):  # type: (str, str) -> dict
-        page = self._get("/{}".format(canonicalize_name(name).replace(".", "-")))
+        page = self._get("/{}/".format(canonicalize_name(name).replace(".", "-")))
         if page is None:
             raise ValueError('No package named "{}"'.format(name))
 


### PR DESCRIPTION
As per
https://warehouse.pypa.io/api-reference/legacy/#get--simple--project--,
the project URL should have a trailing slash.

This was discovered as an issue in an edge case situation,
but should be the standard call regardless.

Edge case explanation:
In a private pypi instance built on artifactory,
set up to serve on https (443) and ignore http (80) requests,
artifactory sends a 301 redirect when called without the slash,
but provides the redirect url as http (due to a bug in artifactory).
This results in an almost-valid call (but missing the slash)
failing by being redirected to a nonsecure call that isn't answered.

For whatever it is worth, there is a Bug filed with Artifactory
for the bad redirect (https://www.jfrog.com/jira/browse/RTFACT-14235),
but it is over a year old with no movement.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [n/a] Added **tests** for changed code.
- [n/a] Updated **documentation** for changed code.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
