### PR TITLE
Better support for private repositories

### DIFF
--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -40,13 +40,3 @@ def test_page_absolute_links_path_are_correct():
     for link in page.links:
         assert link.netloc == "files.pythonhosted.org"
         assert link.path.startswith("/packages/")
-
-
-def test_http_basic_auth_repo(mocker):
-    mock = mocker.patch("poetry.repositories.legacy_repository.get_http_basic_auth")
-    mock.return_value = ("user1", "p4ss")
-
-    repo = MockRepository()
-
-    mock.assert_called_once_with("legacy")
-    assert repo._session.auth == ("user1", "p4ss")


### PR DESCRIPTION
While 0.11.3 added rudimentary support for installation from private repositories (unrelated to this PR: search still seems to not work at all), it does not support some more advanced set ups, such as hosting the private packages on S3 using something like pypicloud. In that case, the Simple index has links to S3 with the authentication in the query string. Sending basic auth headers to S3 will fail, because S3 only allows one kind of authentication (which is already included in the query string). To solve this, I propose to change how authentication for repositories is done in poetry by only sending the username/password to the host for which they are registered in the config.

Right now the PR simply does it in legacy repository. This works for me to add private packages in my setup. Before I try to add tests etc, I would like to get feedback if this approach is acceptable or not.

# Pull Request Check List

- [ ] Make use of the new auth system everywhere it is appropriate
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
