### PR TITLE
Add a --lock option to poetry update

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ poetry update requests toml
 #### Options
 
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--no-dev` : Do not install dev dependencies.
+* `--lock` : Do not perform install (only update the lockfile).
 
 ### add
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -149,6 +149,8 @@ poetry update requests toml
 ### Options
 
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--no-dev` : Do not install dev dependencies.
+* `--lock` : Do not perform install (only update the lockfile).
 
 ## add
 

--- a/poetry/console/commands/update.py
+++ b/poetry/console/commands/update.py
@@ -10,6 +10,7 @@ class UpdateCommand(VenvCommand):
         { --no-dev : Do not install dev dependencies. }
         { --dry-run : Outputs the operations but will not execute anything
                       (implicitly enables --verbose). }
+        { --lock : Do not perform install (only update the lockfile). }
     """
 
     _loggers = ["poetry.repositories.pypi_repository"]
@@ -32,6 +33,7 @@ class UpdateCommand(VenvCommand):
 
         installer.dev_mode(not self.option("no-dev"))
         installer.dry_run(self.option("dry-run"))
+        installer.execute_operations(not self.option("lock"))
 
         # Force update
         installer.update(True)


### PR DESCRIPTION
First up, thanks for Poetry! Seriously impressive bit of kit, particularly all the work on the resolver.

I run [Dependabot](https://dependabot.com), and a couple of customers have asked me to support Poetry (issue [here](https://github.com/dependabot/feedback/issues/57)). It would make it *way* easier for me to do so if you'd be happy to add a `--lock` option to the `poetry update` command, as implemented in this PR. (Alternatively, allowing specific packages to be updated when calling `poetry lock` would work for me, too, but the UI on on that doesn't feel intuitive.)

What do you reckon? `npm` have this pattern with `--package-lock-only`, so there's precedent.

I haven't added a test because there weren't any previously, and the code is pretty trivial.