### PR TITLE
Avoid crashing on missing link

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -298,8 +298,13 @@ class LegacyRepository(PyPiRepository):
         }
 
         links = list(page.links_for_version(Version.parse(version)))
+
+        if not links:
+            return data
+
         urls = {}
         hashes = []
+
         default_link = links[0]
         for link in links:
             if link.is_wheel:


### PR DESCRIPTION
I am not sure if this is a desirable behaviour, but if the remote package is gone, there is an issue with `default_link = links[0]` right after my edits. The list is empty and it crashed with IndexError.