### PR TITLE
make using system-site-packages configurable

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -31,3 +31,7 @@ Defaults to one of the following directories:
 
 ### `repository.<name>`: string
 Set a new alternative repository. See [Repositories](/repositories/) for more information.
+
+### `settings.virtualenvs.system-site-packages`: boolean
+Sets the virtualenv `system-site-packages` flag when creating the virtualenv.
+Defaults to `false`.

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -67,6 +67,11 @@ To remove a repository (repo is a short alias for repositories):
                 lambda val: str(Path(val).resolve()),
                 str(Path(CACHE_DIR) / "virtualenvs"),
             ),
+            "settings.virtualenvs.system-site-packages": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
         }
 
         return unique_config_values

--- a/poetry/utils/venv.py
+++ b/poetry/utils/venv.py
@@ -59,6 +59,9 @@ class Venv(object):
 
                 create_venv = config.setting("settings.virtualenvs.create")
                 root_venv = config.setting("settings.virtualenvs.in-project")
+                system_site_pkgs = config.setting(
+                    "settings.virtualenvs.system-site-packages"
+                )
 
                 venv_path = config.setting("settings.virtualenvs.path")
                 if root_venv:
@@ -102,7 +105,7 @@ class Venv(object):
                         )
                     )
 
-                    cls.build(str(venv))
+                    cls.build(str(venv), system_site_pkgs)
                 else:
                     if io.is_very_verbose():
                         io.writeln(
@@ -132,17 +135,21 @@ class Venv(object):
         return cls(venv)
 
     @classmethod
-    def build(cls, path):
+    def build(cls, path, system_site_packages=False):
         try:
             from venv import EnvBuilder
 
-            builder = EnvBuilder(with_pip=True)
+            builder = EnvBuilder(
+                with_pip=True, system_site_packages=system_site_packages
+            )
             build = builder.create
         except ImportError:
             # We fallback on virtualenv for Python 2.7
             from virtualenv import create_environment
 
-            build = create_environment
+            build: lambda path: create_environment(
+                path, site_packages=system_site_packages
+            )
 
         build(path)
 


### PR DESCRIPTION
This PR adds support for setting 'system-site-packages'. While this does break isolation, I needed it for some packages that aren't pure python (https://graph-tool.skewed.de/).
There are no tests (yet) for this one, since I first want to know if this would ever be a candidate for merging...