### PR TITLE
Added --no-dev option to show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ dependencies:
 
 #### Options
 
+* `--no-dev`: Do not list the dev dependencies.
 * `--tree`: List the dependencies as a tree.
 * `-l|--latest`: Show the latest version.
 *  `-o|--outdated`: Show the latest version but only for packages that are outdated.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -227,6 +227,7 @@ dependencies:
 
 ### Options
 
+* `--no-dev`: Do not list the dev dependencies.
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -10,6 +10,7 @@ class ShowCommand(EnvCommand):
 
     show
         { package? : Package to inspect. }
+        { --no-dev : Do not list the dev dependencies. }
         { --t|tree : List the dependencies as a tree. }
         { --l|latest : Show the latest version. }
         { --o|outdated : Show the latest version
@@ -38,7 +39,7 @@ lists all packages available."""
         if self.option("outdated"):
             self.input.set_option("latest", True)
 
-        locked_repo = self.poetry.locker.locked_repository(True)
+        locked_repo = self.poetry.locker.locked_repository(not self.option("no-dev"))
 
         # Show tree view if requested
         if self.option("tree") and not package:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -13,8 +13,14 @@ def test_show_basic_with_installed_packages(app, poetry, installed):
     pendulum_200 = get_package("pendulum", "2.0.0")
     pendulum_200.description = "Pendulum package"
 
+    pytest_373 = get_package("pytest", "3.7.3")
+    pytest_373.description = "Pytest package"
+    pytest_373.category = "dev"
+
     installed.add_package(cachy_010)
     installed.add_package(pendulum_200)
+    installed.add_package(pytest_373)
+
     poetry.locker.mock_lock_data(
         {
             "package": [
@@ -38,12 +44,22 @@ def test_show_basic_with_installed_packages(app, poetry, installed):
                     "python-versions": "*",
                     "checksum": [],
                 },
+                {
+                    "name": "pytest",
+                    "version": "3.7.3",
+                    "description": "Pytest package",
+                    "category": "dev",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
             ],
             "metadata": {
                 "python-versions": "*",
                 "platform": "*",
                 "content-hash": "123456789",
-                "hashes": {"cachy": [], "pendulum": []},
+                "hashes": {"cachy": [], "pendulum": [], "pytest": []},
             },
         }
     )
@@ -53,6 +69,7 @@ def test_show_basic_with_installed_packages(app, poetry, installed):
     expected = """\
 cachy    0.1.0 Cachy package
 pendulum 2.0.0 Pendulum package
+pytest   3.7.3 Pytest package
 """
 
     assert tester.get_display(True) == expected
@@ -465,6 +482,77 @@ def test_show_all_shows_incompatible_package(app, poetry, installed, repo):
     expected = """\
 cachy     0.1.0 Cachy package
 pendulum  2.0.0 Pendulum package
+"""
+
+    assert tester.get_display(True) == expected
+
+
+def test_show_non_dev_with_basic_installed_packages(app, poetry, installed):
+    command = app.find("show")
+    tester = CommandTester(command)
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+
+    pytest_373 = get_package("pytest", "3.7.3")
+    pytest_373.description = "Pytest package"
+    pytest_373.category = "dev"
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+    installed.add_package(pytest_373)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pytest",
+                    "version": "3.7.3",
+                    "description": "Pytest package",
+                    "category": "dev",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"cachy": [], "pendulum": [], "pytest": []},
+            },
+        }
+    )
+
+    tester.execute([("command", command.get_name()), ("--no-dev", True)])
+
+    expected = """\
+cachy    0.1.0 Cachy package
+pendulum 2.0.0 Pendulum package
 """
 
     assert tester.get_display(True) == expected


### PR DESCRIPTION
This PR intends to allow the `show` command to filter the displayed dependencies based on their category by adding a `--no-dev` option.


# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

