### PR TITLE
Require at least TOML Kit 0.4.4 for performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ cachecontrol = { version = "^0.12.4", extras = ["filecache"] }
 pkginfo = "^1.4"
 html5lib = "^1.0"
 shellingham = "^1.1"
-tomlkit = "^0.4.0"
+tomlkit = "^0.4.4"
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }


### PR DESCRIPTION
This will incorporate the fix for https://github.com/sdispater/tomlkit/issues/10 -- a significant performance bug on Python 2.