### PR TITLE
Support multiple data format for Python sdist distributive

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -47,6 +47,9 @@ from .pypi_repository import PyPiRepository
 class Page:
 
     VERSION_REGEX = re.compile("(?i)([a-z0-9_\-.]+?)-(?=\d)([a-z0-9_.!+-]+)")
+    SUPPORTED_FORMATS = [
+        '.tar.gz', '.whl', '.zip', '.tar.bz2', '.tar.xz', '.tar.Z', '.tar'
+    ]
 
     def __init__(self, url, content, headers):
         if not url.endswith("/"):
@@ -96,7 +99,7 @@ class Page:
 
                 link = Link(url, self, requires_python=pyrequire)
 
-                if link.ext not in [".tar.gz", ".whl", ".zip"]:
+                if link.ext not in self.SUPPORTED_FORMATS:
                     continue
 
                 yield link
@@ -306,7 +309,8 @@ class LegacyRepository(PyPiRepository):
                 urls["bdist_wheel"] = link.url
             elif link.filename.endswith(".tar.gz"):
                 urls["sdist"] = link.url
-            elif link.filename.endswith((".zip", ".bz2")) and "sdist" not in urls:
+            elif link.filename.endswith(
+                    (".zip", ".bz2", ".xz", ".Z", ".tar")) and "sdist" not in urls:
                 urls["sdist"] = link.url
 
             hash = link.hash

--- a/tests/repositories/fixtures/legacy/relative.html
+++ b/tests/repositories/fixtures/legacy/relative.html
@@ -7,6 +7,7 @@
     <h1>Links for poetry</h1>
     <a href="poetry-0.1.0-py3-none-any.whl#sha256=1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163" data-requires-python="&gt;=3.6.0">poetry-0.1.0-py3-none-any.whl</a><br/>
     <a href="poetry-0.1.0.tar.gz#sha256=db33179244321b0b86c6c3645225ff2062ed3495ca16d0d64b3a5df804a82273" data-requires-python="&gt;=3.6.0">poetry-0.1.0.tar.gz</a><br/>
+    <a href="poetry-0.1.1.tar.bz2#sha256=db33179244321b0b86c6c3645225ff2062ed3495ca16d0d64b3a5df804a82273" data-requires-python="&gt;=3.6.0">poetry-0.1.1.tar.bz</a><br/>
     </body>
 </html>
 <!--SERIAL 3907384-->

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -50,3 +50,11 @@ def test_http_basic_auth_repo(mocker):
 
     mock.assert_called_once_with("legacy")
     assert repo._session.auth == ("user1", "p4ss")
+
+
+def test_sdist_format_support():
+    repo = MockRepository()
+    page = repo._get('/relative')
+    bz2_links = list(filter(lambda link: link.ext == '.tar.bz2', page.links))
+    assert len(bz2_links) == 1
+    assert bz2_links[0].filename == 'poetry-0.1.1.tar.bz2'


### PR DESCRIPTION
Accordingly to https://docs.python.org/3/distutils/sourcedist.html
Python sdist can use multiple formats such 
* zip   zip file (.zip)
* gztar gzip’ed tar file (.tar.gz)
* bztar bzip2’ed tar file (.tar.bz2)
* xztar xz’ed tar file (.tar.xz)
* ztar  compressed tar file (.tar.Z)
* tar   tar file (.tar)

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
