### PR TITLE
[DOC] Relative links broken on https://poetry.eustace.io/

### DIFF
--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -1,7 +1,7 @@
 # Basic usage
 
 For the basic usage introduction we will be installing `pendulum`, a datetime library.
-If you have not yet installed Poetry, refer to the [Introduction](/) chapter.
+If you have not yet installed Poetry, refer to the [Introduction](/docs/) chapter.
 
 ## Project setup
 
@@ -69,7 +69,7 @@ It will automatically find a suitable version constraint.
 In our example, we are requesting the `pendulum` package with the version constraint `^1.4`.
 This means any version greater or equal to 1.4.0 and less than 2.0.0 (`>=1.4.0 <2.0.0`).
 
-Please read [versions](/versions/) for more in-depth information on versions, how versions relate to each other, and on version constraints.
+Please read [versions](/docs/versions/) for more in-depth information on versions, how versions relate to each other, and on version constraints.
 
 
 !!!note

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -278,7 +278,7 @@ poetry config [options] [setting-key] [setting-value1] ... [setting-valueN]
 ````
 
 `setting-key` is a configuration option name and `setting-value1` is a configuration value.
-See [Configuration](/configuration/) for all available settings.
+See [Configuration](/docs/configuration/) for all available settings.
 
 ### Options
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Poetry can be configured via the `config` command ([see more about its usage here](/cli/#config))
+Poetry can be configured via the `config` command ([see more about its usage here](/docs/cli/#config))
 or directly in the `config.toml` file that will be automatically be created when you first run that command.
 This file can typically be found in one of the following directories:
 
@@ -33,4 +33,4 @@ Defaults to one of the following directories:
 
 ### `repositories.<name>`: string
 
-Set a new alternative repository. See [Repositories](/repositories/) for more information.
+Set a new alternative repository. See [Repositories](/docs/repositories/) for more information.

--- a/docs/docs/libraries.md
+++ b/docs/docs/libraries.md
@@ -14,7 +14,7 @@ While Poetry does not enforce any convention regarding package versioning,
 it **strongly** recommends to follow [semantic versioning](https://semver.org).
 
 This has many advantages for the end users and allows them to set appropriate
-[version constraints](/versions/).
+[version constraints](/docs/versions/).
 
 ## Lock file
 
@@ -54,7 +54,7 @@ poetry publish
 ```
 
 This will package and publish the library to PyPI, at the condition that you are a registered user
-and you have [configured your credentials](/repositories/#adding-credentials) properly.
+and you have [configured your credentials](/docs/repositories/#adding-credentials) properly.
 
 !!!note
 
@@ -73,7 +73,7 @@ Sometimes, you may want to keep your library private but also being accessible t
 In this case, you will need to use a private repository.
 
 In order to publish to a private repository, you will need to add it to your
-global list of repositories. See [Adding a repository](/repositories/#adding-a-repository)
+global list of repositories. See [Adding a repository](/docs/repositories/#adding-a-repository)
 for more information.
 
 Once this is done, you can actually publish to it like so:


### PR DESCRIPTION
If you check the relative links in https://poetry.eustace.io/docs/basic-usage/ for example, you get a 404 error. I was able to work around it, but thought it was a good idea to have it fixed upstream.

I'm not super sure how to test it, but I did manually edit the URLs and it worked fine. I did a regex search to find the URLs, I think it's exhaustive, but can't be sure

Additionally, I noticed the Introduction can't be clicked in the navigation, probably because it's the index.html page and doesn't have a nav_item.url.

I think this in nav.html
```html
{%- if nav_item.url %}
<a class="{% if nav_item.active%}current{%endif%}" href="{{ base_url }}/{{ nav_item.url }}">{{ nav_item.title }}</a>
{%- else %}
<span class="caption-text">{{ nav_item.title }}</span>
{%- endif %}
```
needs to be edited, but I don't have a good sense of what's the best here, but given that the pages are all URLs I don't see the need for this if statement. I would just have the link created unconditionally.