### PR TITLE
fix: publishing will not fail if wrong credentials

### DIFF
--- a/poetry/masonry/publishing/uploader.py
+++ b/poetry/masonry/publishing/uploader.py
@@ -180,18 +180,16 @@ class Uploader:
         try:
             self._do_upload(session, url)
         except HTTPError as e:
-            if (
-                e.response.status_code not in (403, 400)
-                or e.response.status_code == 400
-                and "was ever registered" not in e.response.text
-            ):
-                raise
-
             # It may be the first time we publish the package
             # We'll try to register it and go from there
-            try:
-                self._register(session, url)
-            except HTTPError:
+            if "was ever registered" in e.response.text:
+                try:
+                    self._register(session, url)
+                except HTTPError as e:
+                    print(e)
+                    raise
+            else:
+                print(e)
                 raise
 
     def _do_upload(self, session, url):


### PR DESCRIPTION
Fixing a bug in publishing functionality:

- When poetry is given wrong credentials, it will act as if publishing succeeded.

My analysis shows that while trying to "catch" the edge case for non-registered package, the case for bad auth credentials is missed.

Simplified the branching logic and made catching the non-registered package case more explicit leads to resolution.

