### PR TITLE
[Documentation] typo in poetry check docs is -> if

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -324,7 +324,7 @@ poetry shell
 ## check
 
 The `check` command validate the structure of the `pyproject.toml` file
-and returns a detailed report is there are any errors.
+and returns a detailed report if there are any errors.
 
 ```bash
 poetry check


### PR DESCRIPTION
Fixed a typo in the `poetry check` cli documentation, replacing "is" with "if".