### PR TITLE
Correct file extension "Project setup"

### DIFF
--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -21,7 +21,7 @@ poetry-demo
 │   └── __init__.py
 └── tests
     ├── __init__.py
-    └── test_poetry_demo
+    └── test_poetry_demo.py
 ```
 
 The `pyproject.toml` file is what is the most important here. This will orchestrate


### PR DESCRIPTION
In ["Project setup"](https://poetry.eustace.io/docs/basic-usage/#project-setup), the file extension is missing for one of the files.