### PR TITLE
Clarify arguments against Pipenv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,25 +237,24 @@ At this point the rest of the resolution is straightforward since there is no mo
 
 #### Install command
 
-When you specify a package to the `install` command it will add it as a wildcard
+When you specify a package to the `install` command without specifying any version constraints, it will add it as a wildcard
 dependency. This means that **any** version of this package can be installed which
 can lead to compatibility issues.
 
 Also, you have to explicitly tell it to not update the locked packages when you
 install new ones. This should be the default.
 
-#### Remove command
+#### Uninstall command
 
-The `remove` command will only remove the package specified but not its dependencies
+The `uninstall` command will only remove the package specified but not its dependencies
 if they are no longer needed.
 
-You either have to use `sync` or `clean` to fix that.
+You have to use `clean` to fix that.
 
 #### Too limited in scope
 
-Finally, the `Pipfile` is just a replacement from `requirements.txt` and, in the end, you will still need to
-populate your `setup.py` file (or `setup.cfg`) with the exact same dependencies you declared in your `Pipfile`.
-So, in the end, you will still need to manage a few configuration files to properly setup your project.
+Finally, the `Pipfile` is just an upgrade from `requirements.txt` and, in the end, you will still need to
+manage a few configuration files to properly setup your project.
 
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ At this point the rest of the resolution is straightforward since there is no mo
 
 #### Install command
 
-When you specify a package to the `install` command without specifying any version constraints, it will add it as a wildcard
-dependency. This means that **any** version of this package can be installed which
-can lead to compatibility issues.
+When you specify a package to the `install` command without specifying any version constraints,
+it will add it as a wildcard dependency. This means that **any** version of this package
+can be installed which can lead to compatibility issues.
 
 Also, you have to explicitly tell it to not update the locked packages when you
 install new ones. This should be the default.
@@ -253,8 +253,8 @@ You have to use `clean` to fix that.
 
 #### Too limited in scope
 
-Finally, the `Pipfile` is just an upgrade from `requirements.txt` and, in the end, you will still need to
-manage a few configuration files to properly setup your project.
+Finally, the `Pipfile` is just an upgrade from `requirements.txt` and, in the end,
+you will still need to manage a few configuration files to properly setup your project.
 
 
 ## Commands


### PR DESCRIPTION
The below are about the sections I've modified, and why.

1. Install command
Pipenv only adds the package as a wildcard dependency if you don't specify any version specifiers. The current wording makes it sound as if Pipenv always does this. I've clarified it by explicitly stating the use without specifying any version specifiers.

2. Remove command
Pipenv's uninstall command seems to have been mixed up with Poetry's own remove command so I've switched them around. I've also removed the statement about `sync` as it just installs packages; only `clean` deals with uninstalling any unused dependencies.

3. Too limited in scope
Honestly I didn't know how to interpret this bit. You shouldn't have a need for both a setup.py and a requirements.txt (or Pipfile), or if you do, and for example you use the setup.py to declare the abstract dependencies your users should install and reserve the requirements.txt for the concrete dependencies only developers should install, you wouldn't have any meaningless duplication. If for some reason you'd like to have both files declare the same dependencies you could either only include them in the requirements.txt and read from it in the setup.py, or put `-e .` in the requirements.txt (slightly different for the Pipfile). A good example of the first case is the [discord.py library](https://github.com/Rapptz/discord.py/blob/1da696258095d5c1171a1cdbe75f56c535c6683e/setup.py#L4-L6), and the [requests library](https://github.com/requests/requests/blob/a6cd380c640087218695bc7c62311a4843777e43/Pipfile#L23-L24) for the second (albeit as a Pipfile). Basically there should never be any cases where there are duplicate dependency specifications so I've removed the entire section about it.

Hopefully I didn't come off as abrasive, especially for that last bit. Poetry and Pipenv are both awesome projects but I'd hate to see one get overlooked for the wrong reasons.