### PR TITLE
Fix warnings with Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"
+    - python: "3.7"
+      dist: xenial
 
     - stage: linting
       python: "3.6"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ $ poetry run pytest tests/
 Poetry uses the [black](https://github.com/ambv/black) coding style and you must ensure that your
 code follows it. If not, the CI will fail and your Pull Request will not be merged.
 
-To make sure that you don't accidently commit code that does not follow the coding style, you can
+To make sure that you don't accidentally commit code that does not follow the coding style, you can
 install a pre-commit hook that will check that everything is in order:
 
 ```bash
@@ -117,4 +117,3 @@ will not be merged.
 * Fill in [the required template](https://github.com/sdispater/poetry/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
 * Be sure that you pull request contains tests that cover the changed or added code.
 * If you changes warrant a documentation change, the pull request must also update the documentation.
-

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -153,7 +153,7 @@ class Application(BaseApplication):
                 line[x : x + (width - 4)] for x in range(0, len(line), width - 4)
             ]:
                 line_length = (
-                    len(re.sub("\[[^m]*m", "", formatter.format(splitline))) + 4
+                    len(re.sub(r"\[[^m]*m", "", formatter.format(splitline))) + 4
                 )
                 lines.append((splitline, line_length))
 

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -102,7 +102,7 @@ To remove a repository (repo is a short alias for repositories):
 
         # show the value if no value is provided
         if not self.argument("value") and not self.option("unset"):
-            m = re.match("^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
+            m = re.match(r"^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
             if m:
                 if not m.group(1):
                     value = {}
@@ -144,7 +144,7 @@ To remove a repository (repo is a short alias for repositories):
             )
 
         # handle repositories
-        m = re.match("^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
+        m = re.match(r"^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
         if m:
             if not m.group(1):
                 raise ValueError("You cannot remove the [repositories] section")
@@ -173,7 +173,7 @@ To remove a repository (repo is a short alias for repositories):
             )
 
         # handle auth
-        m = re.match("^(http-basic)\.(.+)", self.argument("key"))
+        m = re.match(r"^(http-basic)\.(.+)", self.argument("key"))
         if m:
             if self.option("unset"):
                 if not self._auth_config.setting(
@@ -278,7 +278,7 @@ To remove a repository (repo is a short alias for repositories):
                     if k is None:
                         k = ""
 
-                    k += re.sub("^config\.", "", key + ".")
+                    k += re.sub(r"^config\.", "", key + ".")
                     if setting and len(setting) > 1:
                         setting = ".".join(setting.split(".")[1:])
 

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -15,7 +15,7 @@ from ..utils.module import Module
 from ..utils.package_include import PackageInclude
 
 
-AUTHOR_REGEX = re.compile("(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
+AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
 
 
 class Builder(object):

--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -280,7 +280,7 @@ class SdistBuilder(Builder):
     ):
         main = []
         extras = defaultdict(list)
-        req_regex = re.compile("^(.+) \((.+)\)$")
+        req_regex = re.compile(r"^(.+) \((.+)\)$")
 
         for dependency in dependencies:
             if dependency.is_optional():

--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -179,8 +179,8 @@ class WheelBuilder(Builder):
     @property
     def wheel_filename(self):  # type: () -> str
         return "{}-{}-{}.whl".format(
-            re.sub("[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE),
-            re.sub("[^\w\d.]+", "_", self._meta.version, flags=re.UNICODE),
+            re.sub(r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE),
+            re.sub(r"[^\w\d.]+", "_", self._meta.version, flags=re.UNICODE),
             self.tag,
         )
 
@@ -190,8 +190,8 @@ class WheelBuilder(Builder):
         )
 
     def dist_info_name(self, distribution, version):  # type: (...) -> str
-        escaped_name = re.sub("[^\w\d.]+", "_", distribution, flags=re.UNICODE)
-        escaped_version = re.sub("[^\w\d.]+", "_", version, flags=re.UNICODE)
+        escaped_name = re.sub(r"[^\w\d.]+", "_", distribution, flags=re.UNICODE)
+        escaped_version = re.sub(r"[^\w\d.]+", "_", version, flags=re.UNICODE)
 
         return "{}-{}.dist-info".format(escaped_name, escaped_version)
 

--- a/poetry/masonry/publishing/uploader.py
+++ b/poetry/masonry/publishing/uploader.py
@@ -60,9 +60,9 @@ class Uploader:
             dist.glob(
                 "{}-{}-*.whl".format(
                     re.sub(
-                        "[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE
+                        r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE
                     ),
-                    re.sub("[^\w\d.]+", "_", version, flags=re.UNICODE),
+                    re.sub(r"[^\w\d.]+", "_", version, flags=re.UNICODE),
                 )
             )
         )

--- a/poetry/packages/__init__.py
+++ b/poetry/packages/__init__.py
@@ -62,7 +62,7 @@ def dependency_from_pep_508(name):
             link = Link(path_to_url(os.path.normpath(os.path.abspath(link.path))))
         # wheel file
         if link.is_wheel:
-            m = re.match("^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))", link.filename)
+            m = re.match(r"^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))", link.filename)
             if not m:
                 raise ValueError("Invalid wheel name: {}".format(link.filename))
 

--- a/poetry/packages/constraints/generic_constraint.py
+++ b/poetry/packages/constraints/generic_constraint.py
@@ -84,7 +84,7 @@ class GenericConstraint(BaseConstraint):
         """
         pretty_constraint = constraints
 
-        or_constraints = re.split("\s*\|\|?\s*", constraints.strip())
+        or_constraints = re.split(r"\s*\|\|?\s*", constraints.strip())
         or_groups = []
         for constraints in or_constraints:
             and_constraints = re.split(
@@ -116,12 +116,12 @@ class GenericConstraint(BaseConstraint):
 
     @classmethod
     def _parse_constraint(cls, constraint):
-        m = re.match("(?i)^v?[xX*](\.[xX*])*$", constraint)
+        m = re.match(r"(?i)^v?[xX*](\.[xX*])*$", constraint)
         if m:
             return (EmptyConstraint(),)
 
         # Basic Comparators
-        m = re.match("^(!=|==?)?\s*(.*)", constraint)
+        m = re.match(r"^(!=|==?)?\s*(.*)", constraint)
         if m:
             return (GenericConstraint(m.group(1) or "=", m.group(2)),)
 

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -19,7 +19,7 @@ from .directory_dependency import DirectoryDependency
 from .file_dependency import FileDependency
 from .vcs_dependency import VCSDependency
 
-AUTHOR_REGEX = re.compile("(?u)^(?P<name>[- .,\w\d'’\"()]+)(?: <(?P<email>.+?)>)?$")
+AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+)(?: <(?P<email>.+?)>)?$")
 
 
 class Package(object):

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -508,8 +508,8 @@ class Provider:
 
         if message.startswith("fact:"):
             if "depends on" in message:
-                m = re.match("fact: (.+?) depends on (.+?) \((.+?)\)", message)
-                m2 = re.match("(.+?) \((.+?)\)", m.group(1))
+                m = re.match(r"fact: (.+?) depends on (.+?) \((.+?)\)", message)
+                m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
                 if m2:
                     name = m2.group(1)
                     version = " (<comment>{}</comment>)".format(m2.group(2))
@@ -531,19 +531,19 @@ class Provider:
                 )
             else:
                 message = re.sub(
-                    "(?<=: )(.+?) \((.+?)\)",
+                    r"(?<=: )(.+?) \((.+?)\)",
                     "<info>\\1</info> (<comment>\\2</comment>)",
                     message,
                 )
                 message = "<fg=blue>fact</>: {}".format(message.split("fact: ")[1])
         elif message.startswith("selecting "):
             message = re.sub(
-                "selecting (.+?) \((.+?)\)",
+                r"selecting (.+?) \((.+?)\)",
                 "<fg=blue>selecting</> <info>\\1</info> (<comment>\\2</comment>)",
                 message,
             )
         elif message.startswith("derived:"):
-            m = re.match("derived: (.+?) \((.+?)\)$", message)
+            m = re.match(r"derived: (.+?) \((.+?)\)$", message)
             if m:
                 message = "<fg=blue>derived</>: <info>{}</info> (<comment>{}</comment>)".format(
                     m.group(1), m.group(2)
@@ -553,9 +553,9 @@ class Provider:
                     message.split("derived: ")[1]
                 )
         elif message.startswith("conflict:"):
-            m = re.match("conflict: (.+?) depends on (.+?) \((.+?)\)", message)
+            m = re.match(r"conflict: (.+?) depends on (.+?) \((.+?)\)", message)
             if m:
-                m2 = re.match("(.+?) \((.+?)\)", m.group(1))
+                m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
                 if m2:
                     name = m2.group(1)
                     version = " (<comment>{}</comment>)".format(m2.group(2))

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -46,7 +46,7 @@ from .pypi_repository import PyPiRepository
 
 class Page:
 
-    VERSION_REGEX = re.compile("(?i)([a-z0-9_\-.]+?)-(?=\d)([a-z0-9_.!+-]+)")
+    VERSION_REGEX = re.compile(r"(?i)([a-z0-9_\-.]+?)-(?=\d)([a-z0-9_.!+-]+)")
 
     def __init__(self, url, content, headers):
         if not url.endswith("/"):

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -290,7 +290,7 @@ class PyPiRepository(Repository):
 
                 # If bdist_wheel, check if it's universal
                 filename = url["filename"]
-                if not re.search("-py2\.py3-none-any.whl", filename):
+                if not re.search(r"-py2\.py3-none-any.whl", filename):
                     continue
 
                 urls[dist_type] = url["url"]

--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -16,7 +16,7 @@ def parse_constraint(constraints):  # type: (str) -> VersionConstraint
     if constraints == "*":
         return VersionRange()
 
-    or_constraints = re.split("\s*\|\|?\s*", constraints.strip())
+    or_constraints = re.split(r"\s*\|\|?\s*", constraints.strip())
     or_groups = []
     for constraints in or_constraints:
         and_constraints = re.split(
@@ -46,7 +46,7 @@ def parse_constraint(constraints):  # type: (str) -> VersionConstraint
 
 
 def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
-    m = re.match("(?i)^v?[xX*](\.[xX*])*$", constraint)
+    m = re.match(r"(?i)^v?[xX*](\.[xX*])*$", constraint)
     if m:
         return VersionRange()
 

--- a/poetry/semver/patterns.py
+++ b/poetry/semver/patterns.py
@@ -2,20 +2,20 @@ import re
 
 MODIFIERS = (
     "[._-]?"
-    "((?!post)(?:beta|b|c|pre|RC|alpha|a|patch|pl|p|dev)(?:(?:[.-]?\d+)*)?)?"
-    "([+-]?([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?"
+    r"((?!post)(?:beta|b|c|pre|RC|alpha|a|patch|pl|p|dev)(?:(?:[.-]?\d+)*)?)?"
+    r"([+-]?([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?"
 )
 
-_COMPLETE_VERSION = "v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?{}(?:\+[^\s]+)?".format(
+_COMPLETE_VERSION = r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?{}(?:\+[^\s]+)?".format(
     MODIFIERS
 )
 
 COMPLETE_VERSION = re.compile("(?i)" + _COMPLETE_VERSION)
 
-CARET_CONSTRAINT = re.compile("(?i)^\^({})$".format(_COMPLETE_VERSION))
+CARET_CONSTRAINT = re.compile(r"(?i)^\^({})$".format(_COMPLETE_VERSION))
 TILDE_CONSTRAINT = re.compile("(?i)^~(?!=)({})$".format(_COMPLETE_VERSION))
 TILDE_PEP440_CONSTRAINT = re.compile("(?i)^~=({})$".format(_COMPLETE_VERSION))
-X_CONSTRAINT = re.compile("^(!=|==)?\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.[xX*])+$")
+X_CONSTRAINT = re.compile(r"^(!=|==)?\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.[xX*])+$")
 BASIC_CONSTRAINT = re.compile(
-    "(?i)^(<>|!=|>=?|<=?|==?)?\s*({}|dev)".format(_COMPLETE_VERSION)
+    r"(?i)^(<>|!=|>=?|<=?|==?)?\s*({}|dev)".format(_COMPLETE_VERSION)
 )

--- a/poetry/semver/version.py
+++ b/poetry/semver/version.py
@@ -280,7 +280,7 @@ class Version(VersionRange):
         if not pre:
             return
 
-        m = re.match("(?i)^(a|alpha|b|beta|c|pre|rc|dev)[-.]?(\d+)?$", pre)
+        m = re.match(r"(?i)^(a|alpha|b|beta|c|pre|rc|dev)[-.]?(\d+)?$", pre)
         if not m:
             return
 

--- a/poetry/utils/appdirs.py
+++ b/poetry/utils/appdirs.py
@@ -64,7 +64,7 @@ def user_cache_dir(appname):
 
 
 def user_data_dir(appname, roaming=False):
-    """
+    r"""
     Return full path to the user-specific data dir for this application.
 
         "appname" is the name of application.
@@ -137,7 +137,7 @@ def user_config_dir(appname, roaming=True):
 # for the discussion regarding site_config_dirs locations
 # see <https://github.com/pypa/pip/issues/1733>
 def site_config_dirs(appname):
-    """Return a list of potential user-shared config dirs for this application.
+    r"""Return a list of potential user-shared config dirs for this application.
 
         "appname" is the name of application.
 

--- a/poetry/version/version.py
+++ b/poetry/version/version.py
@@ -12,7 +12,7 @@ _Version = namedtuple("_Version", ["epoch", "release", "dev", "pre", "post", "lo
 
 
 VERSION_PATTERN = re.compile(
-    """
+    r"""
     ^
     v?
     (?:


### PR DESCRIPTION
Before:
```
$ pytest
src/poetry/poetry/utils/appdirs.py:92: DeprecationWarning: invalid escape sequence \D
  """
src/poetry/poetry/utils/appdirs.py:154: DeprecationWarning: invalid escape sequence \D
  """
...
322 passed, 42 warnings in 8.24 seconds
```

After:

```
$ pytest
...
322 passed, 2 warnings in 5.08 seconds
```

Note: the remaining 2 warnings are coming from jsonschema and html5lib, we can probably ignore them for now. (Maybe I'll open an issue upstream)

Cheers!