### PR TITLE
Handle missing license ('NoneType' object has no attribute 'lower')

### DIFF
--- a/poetry/spdx/__init__.py
+++ b/poetry/spdx/__init__.py
@@ -11,7 +11,7 @@ def license_by_id(identifier):
     if _licenses is None:
         load_licenses()
 
-    id = identifier.lower()
+    id = identifier.lower() if identifier else None
 
     if id not in _licenses:
         raise ValueError("Invalid license id: {}".format(identifier))


### PR DESCRIPTION
After upgrading to `0.12.0`, I ran into the following exception:

```
poetry lock -v

[AttributeError]
'NoneType' object has no attribute 'lower'

Exception trace:
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/cleo/application.py in run() at line 94
   status_code = self.do_run(input_, output_)
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/console/application.py in do_run() at line 88
   return super(Application, self).do_run(i, o)
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/cleo/application.py in do_run() at line 197
   status_code = command.run(input_, output_)
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/console/commands/command.py in run() at line 77
   return super(BaseCommand, self).run(i, o)
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/cleo/commands/base_command.py in run() at line 136
   self.initialize(input_, output_)
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/console/commands/env_command.py in initialize() at line 16
   o, self.poetry.package.name, cwd=self.poetry.file.parent
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/console/commands/command.py in poetry() at line 62
   return self.get_application().poetry
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/console/application.py in poetry() at line 60
   self._poetry = Poetry.create(os.getcwd())
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/poetry.py in create() at line 120
   license_ = license_by_id(local_config.get("license"))
 /Users/Browning/.pyenv/versions/3.7.0/lib/python3.7/site-packages/poetry/spdx/__init__.py in license_by_id() at line 14
   id = identifier.lower()

lock
```

My understanding is that licenses are optional so we need to handle the case where the `pyproject.toml` does not contain a `license` key.

---

Fixes #501 