### PR TITLE
fix repository links (poet ➜ poetry)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 homepage = "https://poetry.eustace.io/"
-repository = "https://github.com/sdispater/poet"
+repository = "https://github.com/sdispater/poetry"
 documentation = "https://poetry.eustace.io/docs"
 
 keywords = ["packaging", "dependency", "poetry"]

--- a/tests/fixtures/complete.toml
+++ b/tests/fixtures/complete.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.rst"
 
 homepage = "https://poetry.eustace.io/"
-repository = "https://github.com/sdispater/poet"
+repository = "https://github.com/sdispater/poetry"
 documentation = "https://poetry.eustace.io/docs"
 
 keywords = ["packaging", "dependency", "poetry"]

--- a/tests/utils/fixtures/pyproject.toml
+++ b/tests/utils/fixtures/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 homepage = "https://poetry.eustace.io/"
-repository = "https://github.com/sdispater/poet"
+repository = "https://github.com/sdispater/poetry"
 documentation = "https://poetry.eustace.io/docs"
 
 keywords = ["packaging", "dependency", "poetry"]


### PR DESCRIPTION
Seems there still were some `poet` repository links lingering.
This causes https://pypi.org/project/poetry/ to link `poet` repository and its statistics instead of `poetry`.