### PR TITLE
Remove duplicate customize_install function from get-poetry.py

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -412,7 +412,7 @@ class Installer:
     def customize_install(self):
         if not self._accept_all:
             print("Before we start, please answer the following questions.")
-            print("You may simple press the Enter key to keave unchanged.")
+            print("You may simply press the Enter key to leave unchanged.")
 
             modify_path = input("Modify PATH variable? ([y]/n) ") or "y"
             if modify_path.lower() in {"n", "no"}:
@@ -433,17 +433,6 @@ class Installer:
             print("")
 
         return True
-
-    def customize_install(self):
-        if not self._accept_all:
-            print("Before we start, please answer the following questions.")
-            print("You may simple press the Enter key to keave unchanged.")
-
-            modify_path = input("Modify PATH variable? ([y]/n) ") or "y"
-            if modify_path.lower() in {"n", "no"}:
-                self._modify_path = False
-
-            print("")
 
     def ensure_home(self):
         """


### PR DESCRIPTION
Looks like there were two identical copies of the customize_install function
in the installer script. I removed one and fixed a couple minor typos
along the way.


This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!