### PR TITLE
Support symlinking the poetry script

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -195,7 +195,7 @@ import glob
 import sys
 import os
 
-lib = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "lib"))
+lib = os.path.normpath(os.path.join(os.path.realpath(__file__), "../..", "lib"))
 
 sys.path.insert(0, lib)
 


### PR DESCRIPTION
It is common to symlink executables installed at different locations to a single directory, so that `PATH` doesn't have to contain dozens of entries. The `poetry` script created by the `get-poetry.py` installer doesn't support being symlinked to from somewhere else. This patch fixes that.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!