### PR TITLE
Fix pip installer error for directory sources

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -25,7 +25,7 @@ class PipInstaller(BaseInstaller):
 
     def install(self, package, update=False):
         if package.source_type == "directory":
-            self.install_directory(package, update=update)
+            self.install_directory(package)
 
             return
 


### PR DESCRIPTION
This change updates the method parameters used when calling
`PipInstaller.install_directory` to remove the `update` parameter.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
Might be missing something, but looks like there is no testing for this code path at all as tests use the `NoopInstaller`.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
