### PR TITLE
Use configured repositories as sources by default

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -54,7 +54,11 @@ with the `--username` and `--password` options.
 Now that you can publish to your private repository, you need to be able to
 install dependencies from it.
 
-For that, you have to edit your `pyproject.toml` file, like so
+By default, Poetry uses all repositories configured as shown above for package
+installation.
+
+If you would like to use a repository that was not configured like above, you have to
+edit your `pyproject.toml` file, like so
 
 ```toml
 [[tool.poetry.source]]

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -46,6 +46,17 @@ class Poetry:
         for source in self._local_config.get("source", []):
             self._pool.add_repository(self.create_legacy_repository(source))
 
+        # Add any additional repositories configured globally as source
+        # This is done after local config sources and before PyPI
+        extra_repositories = self._config.setting("repositories", default={})
+        for repository_name, repository_config in extra_repositories.items():
+            if "url" in repository_config:
+                self._pool.add_repository(
+                    self.create_legacy_repository(
+                        {"name": repository_name, "url": repository_config["url"]}
+                    )
+                )
+
         # Always put PyPI last to prefer private repositories
         self._pool.add_repository(PyPiRepository())
 

--- a/tests/fixtures/config_with_repositories/auth.toml
+++ b/tests/fixtures/config_with_repositories/auth.toml
@@ -1,0 +1,1 @@
+[http-basic]

--- a/tests/fixtures/config_with_repositories/config.toml
+++ b/tests/fixtures/config_with_repositories/config.toml
@@ -1,0 +1,5 @@
+[settings]
+
+[repositories]
+[repositories.foo]
+url = "https://baz.com"

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -23,3 +23,8 @@ classifiers = [
 # Requirements
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"
+
+# Extra Source
+[[tool.poetry.source]]
+name = "foo"
+url = "https://bar.com"


### PR DESCRIPTION
This change adds globally configured extra repositories from config.toml as dependency sources. These are added after project specific sources and before PyPI.

The motivation behind this change was to enable a cleaner configuration of private repositories/mirrors under automated pipeline build environments without hard coding repository configurations within the project sources. Additionally, this provides functionality similar to pip's extra_index config allowing global configuration of repositories.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

Resolves: #625 