### PR TITLE
Fasten the excluded file check

### DIFF
--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -63,7 +63,10 @@ class Builder(object):
 
             result.append(file)
 
-        return result
+        # The list of excluded files might be big and we will do a lot
+        # containment check (x in excluded).
+        # Returning a set make those tests much much faster.
+        return set(result)
 
     def find_files_to_add(self, exclude_build=True):  # type: () -> list
         """


### PR DESCRIPTION
Before we build a potentially very big list of all the excluded file matching
every exclude pattern, which could be a lot and then do a containment check on
the resulting list.

A first step to speed up the process is to returns a set instead of a list so
containment checks will not be dependent to the number of matching files
anymore.

If the set still ends up being too large, introducing an intermediary solution
that check if a file name match a glob pattern instead of expanding the glob
pattern might be a good solution. Right now, it seems overkill in comparison
of this patch.

With this patch, building my project that exclude `nodes_modules/**/*` went
from 4 minutes to 7 seconds.

Fix #603

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
