### PR TITLE
401 - Add venv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,22 @@ dependencies:
  - pytzdata >=2017.2.2
 ```
 
+
+### venv
+
+To find the path to the virtualenv directory, you can use the `venv` command.
+
+```bash
+poetry venv
+```
+
+This may be helpful if you need to find paths relative to the virtualenv. For
+example if you'd like to activate the virtualenv manually.
+
+```bash
+source ${poetry venv}/bin/activate
+```
+
 #### Options
 
 * `--no-dev`: Do not list the dev dependencies.

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -30,6 +30,7 @@ from .commands import ScriptCommand
 from .commands import SearchCommand
 from .commands import ShellCommand
 from .commands import ShowCommand
+from .commands.venv import VenvCommand
 from .commands import UpdateCommand
 from .commands import VersionCommand
 
@@ -124,6 +125,7 @@ class Application(BaseApplication):
             ShowCommand(),
             UpdateCommand(),
             VersionCommand(),
+            VenvCommand(),
         ]
 
         # Cache commands

--- a/poetry/console/commands/venv.py
+++ b/poetry/console/commands/venv.py
@@ -5,8 +5,9 @@ class VenvCommand(Command):
     """
     Print venv path
     """
+
     def __init__(self):
-        super(VenvCommand, self).__init__('venv')
+        super(VenvCommand, self).__init__("venv")
 
     def handle(self):
         from ...utils.env import Env

--- a/poetry/console/commands/venv.py
+++ b/poetry/console/commands/venv.py
@@ -1,0 +1,16 @@
+from .command import Command
+
+
+class VenvCommand(Command):
+    """
+    Print venv path
+    """
+    def __init__(self):
+        super(VenvCommand, self).__init__('venv')
+
+    def handle(self):
+        from ...utils.env import Env
+
+        poetry = self.poetry
+        env = Env.get(cwd=poetry.file.parent)
+        self.line(str(env.path))

--- a/tests/console/commands/test_venv.py
+++ b/tests/console/commands/test_venv.py
@@ -1,0 +1,16 @@
+from cleo.testers import CommandTester
+
+from poetry.utils.env import MockEnv
+
+
+def test_venv_prints_path(app, mocker):
+    venv_path = '/path/to/cache_dir/pypoetry/virtualenvs/myproj-3.6'
+    mock_env = MockEnv()
+    mock_env._path = venv_path
+    mocker.patch("poetry.utils.env.Env.get", return_value=mock_env)
+
+    command = app.find("venv")
+    tester = CommandTester(command)
+    tester.execute([("command", command.get_name())])
+
+    assert tester.get_display(True).strip() == venv_path

--- a/tests/console/commands/test_venv.py
+++ b/tests/console/commands/test_venv.py
@@ -4,7 +4,7 @@ from poetry.utils.env import MockEnv
 
 
 def test_venv_prints_path(app, mocker):
-    venv_path = '/path/to/cache_dir/pypoetry/virtualenvs/myproj-3.6'
+    venv_path = "/path/to/cache_dir/pypoetry/virtualenvs/myproj-3.6"
     mock_env = MockEnv()
     mock_env._path = venv_path
     mocker.patch("poetry.utils.env.Env.get", return_value=mock_env)


### PR DESCRIPTION
This makes it easier to programmatically access paths relative to the
virtualenv.  A common use case is to activate the virtualenv

    source ${poetry venv}/bin/activate

This programmatic access can be used to automate virtualenvs upon cd-ing
into a project or as an alias, for example

https://github.com/sdispater/poetry/issues/401

# Pull Request Check List
- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

I'm basing this change on the `master` branch, as the `develop` branch appears to be behind master. For example, the MockEnv class does not exist yet on develop, despite existing in master.

I'm just throwing this up here to get this ticket started, but I'm up to alternative ideas about implementation.

A few other thoughts:
1. Maybe we should have an `info` command which is like `debug:info` but returns a single field. e.g. `poetry info:venv` would return the venv while `poetry info:python_version` would return the python version.
2. Or perhaps we merge this with debug:info so that it's something like `debug:info:venv` (although given that it would become api, I wouldn't like the debug prefix), while `debug:info` gives you all the info
3. I could also imagine a command to directly get the activate script. Either returning the path to the script:
`source ${poetry activate}`
or the contents of the activate script:
`eval ${poetry activate}`