### PR TITLE
Fixes #614: only display git exectuable missing warning in verbose modes

### DIFF
--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import Set
 from typing import Union
+from warnings import catch_warnings
 
 from poetry.utils._compat import Path
 from poetry.utils._compat import basestring
@@ -45,7 +46,12 @@ class Builder(object):
     @lru_cache(maxsize=None)
     def find_excluded_files(self):  # type: () -> Set[str]
         # Checking VCS
-        vcs = get_vcs(self._path)
+        with catch_warnings():
+            try:
+                vcs = get_vcs(self._path)
+            except Warning as warning:
+                self._io.writeln(warning, verbosity=self._io.VERBOSITY_VERY_VERBOSE)
+
         if not vcs:
             vcs_ignored_files = set()
         else:

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -2,12 +2,12 @@
 import re
 import shutil
 import tempfile
+import warnings
 
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Set
 from typing import Union
-from warnings import catch_warnings
 
 from poetry.utils._compat import Path
 from poetry.utils._compat import basestring
@@ -46,11 +46,14 @@ class Builder(object):
     @lru_cache(maxsize=None)
     def find_excluded_files(self):  # type: () -> Set[str]
         # Checking VCS
-        with catch_warnings():
-            try:
-                vcs = get_vcs(self._path)
-            except Warning as warning:
-                self._io.writeln(warning, verbosity=self._io.VERBOSITY_VERY_VERBOSE)
+        with warnings.catch_warnings():
+            if self._io.is_verbose() or self._io.is_very_verbose():
+                action = "always"
+            else:
+                action = "ignore"
+            warnings.simplefilter(action)
+            vcs = get_vcs(self._path)
+            warnings.resetwarnings()
 
         if not vcs:
             vcs_ignored_files = set()

--- a/sonnet
+++ b/sonnet
@@ -7,6 +7,7 @@ import sys
 import tarfile
 
 from gzip import GzipFile
+from warnings import catch_warnings
 
 from cleo import Application
 from cleo import Command
@@ -61,7 +62,12 @@ class MakeReleaseCommand(Command):
         pool = Pool()
         pool.add_repository(project.locker.locked_repository(with_dev_reqs=True))
 
-        vcs = get_vcs(Path(__file__).parent)
+        with catch_warnings():
+            try:
+                vcs = get_vcs(Path(__file__).parent)
+            except Warning as warning:
+                self._io.writeln(warning, verbosity=self._io.VERBOSITY_VERY_VERBOSE)
+
         if vcs:
             vcs_excluded = [str(f) for f in vcs.get_ignored_files()]
         else:

--- a/sonnet
+++ b/sonnet
@@ -5,9 +5,9 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import warnings
 
 from gzip import GzipFile
-from warnings import catch_warnings
 
 from cleo import Application
 from cleo import Command
@@ -62,11 +62,14 @@ class MakeReleaseCommand(Command):
         pool = Pool()
         pool.add_repository(project.locker.locked_repository(with_dev_reqs=True))
 
-        with catch_warnings():
-            try:
-                vcs = get_vcs(Path(__file__).parent)
-            except Warning as warning:
-                self._io.writeln(warning, verbosity=self._io.VERBOSITY_VERY_VERBOSE)
+        with warnings.catch_warnings():
+            if self._io.is_verbose() or self._io.is_very_verbose():
+                action = "always"
+            else:
+                action = "ignore"
+            warnings.simplefilter(action)
+            vcs = get_vcs(Path(__file__).parent)
+            warnings.resetwarnings()
 
         if vcs:
             vcs_excluded = [str(f) for f in vcs.get_ignored_files()]


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I am not sure if you would like tests or documentation changed for this small change. If additional tests would be preferred, I think we would need to simulate `git` executable being missing, which seems somewhat strange. Happy to look into that if you'd like.

Best,
Xander