### PR TITLE
Bugfix cope with arbitrary equals

### DIFF
--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -1,3 +1,5 @@
+import re
+
 from poetry.packages import Package
 from poetry.utils.env import Env
 
@@ -17,7 +19,7 @@ class InstalledRepository(Repository):
         freeze_output = env.run("pip", "freeze")
         for line in freeze_output.split("\n"):
             if "==" in line:
-                name, version = line.split("==")
+                name, version = re.split("={2,3}", line)
                 repo.add_package(Package(name, version, version))
             elif line.startswith("-e "):
                 line = line[3:].strip()

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -4,6 +4,7 @@ from poetry.utils.env import MockEnv as BaseMockEnv
 
 FREEZE_RESULTS = """cleo==0.6.8
 -e git+https://github.com/sdispater/pendulum.git@bb058f6b78b2d28ef5d9a5e759cfa179a1a713d6#egg=pendulum
+orator===0.9.8
 """
 
 
@@ -18,7 +19,7 @@ class MockEnv(BaseMockEnv):
 def test_load():
     repository = InstalledRepository.load(MockEnv())
 
-    assert len(repository.packages) == 2
+    assert len(repository.packages) == 3
 
     cleo = repository.packages[0]
     assert cleo.name == "cleo"
@@ -30,3 +31,7 @@ def test_load():
     assert pendulum.source_type == "git"
     assert pendulum.source_url == "https://github.com/sdispater/pendulum.git"
     assert pendulum.source_reference == "bb058f6b78b2d28ef5d9a5e759cfa179a1a713d6"
+
+    orator = repository.packages[2]
+    assert orator.name == "orator"
+    assert orator.version.text == "0.9.8"


### PR DESCRIPTION
When loading installed packages pip freeze can output lines with
``===``, arbitrary equals, qualifiers instead of ``==``. This allows
poetry to parse either.

This fixes #433, based on the suggestion present in the discussion.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
