### PR TITLE
Fix case of '-f' switch for poetry build

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Note that, at the moment, only pure python wheels are supported.
 
 #### Options
 
-* `-F|--format`: Limit the format to either wheel or sdist.
+* `-f|--format`: Limit the format to either wheel or sdist.
 
 ### publish
 


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

-------------

In version 0.12.8, attempting to use an uppercase 'F' to designate build format yields the error: 

[NoSuchOption]
 The "-F" options does not exist.
 build [-f|--format FORMAT]

Switching to lowercase 'f' to match the CLI's current configuration.


