### PR TITLE
Fix truncated bin paths with "." when not on windows

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -301,7 +301,10 @@ class Env(object):
         """
         Return path to the given executable.
         """
-        bin_path = (self._bin_dir / bin).with_suffix(".exe" if self._is_windows else "")
+        bin_path = self._bin_dir / bin
+        if self._is_windows:
+            bin_path = bin_path.with_suffix(".exe")
+
         if not bin_path.exists():
             return bin
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,0 +1,25 @@
+from poetry.utils.env import Env
+from poetry.utils._compat import Path
+import sys
+
+
+def test_execute_windows_calls_exe(mocker):
+    sys.platform = "win32"
+    subprocess_call = mocker.patch("subprocess.call")
+    Env(Path("/")).execute("test")
+    assert subprocess_call.call_args[0][0][0].endswith("/test.exe")
+
+
+def test_execute_non_windows_ignores_exe(mocker):
+    sys.platform = "linux"
+    subprocess_call = mocker.patch("subprocess.call")
+    Env(Path("/")).execute("test")
+    called_path = subprocess_call.call_args
+    assert subprocess_call.call_args[0][0][0].endswith("/test")
+
+
+def test_execute_non_windows_does_not_stem_input(mocker):
+    sys.platform = "linux"
+    subprocess_call = mocker.patch("subprocess.call")
+    Env(Path("/")).execute("test.test")
+    assert subprocess_call.call_args[0][0][0].endswith("/test.test")


### PR DESCRIPTION
This pull requests fixes a bug revealed by [this commit](https://github.com/sdispater/poetry/commit/48e21915306dd6a8d69b9e94d5609d4d3a8845b2) in the 0.12.8 release a few days ago. When trying to call a module with a `.` in its name, poetry would truncate the module name and fail. For example, `poetry run py.test` would fail, trying to call a binary named `py`.

It looks like this happens because the path resolver tries to add a `.exe` extension for Windows support, but otherwise _still calls_ `.with_suffix("")`, so any text after a final `.` would be interpreted as a file extension and be truncated, in order to match the file extension `""`.

I've unwrapped the Windows guard so `with_suffix` does not get called with an empty string, and added Env tests which override `sys.platform` in order to make assertions.

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. _(N/A?)_

