### PR TITLE
Use install in favour of deprecated develop command in contributing documentation

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -97,7 +97,7 @@ Now, you will need to install the required dependency for Poetry and be sure tha
 tests are passing on your machine:
 
 ```bash
-$ poetry develop
+$ poetry install
 $ poetry run pytest tests/
 ```
 


### PR DESCRIPTION
Simple documentation update. `develop` has been deprecated in [this commit][1], `install` will
automatically use development mode, so this should be shown in the documentation for contributers.

[1]: 48ed586bc7133a74c612503dd14c779215ff61c9
