### PR TITLE
bugfix search only names

### DIFF
--- a/poetry/console/commands/search.py
+++ b/poetry/console/commands/search.py
@@ -15,7 +15,7 @@ class SearchCommand(Command):
 
         flags = PyPiRepository.SEARCH_FULLTEXT
         if self.option("only-name"):
-            flags = PyPiRepository.SEARCH_FULLTEXT
+            flags = PyPiRepository.SEARCH_NAME
 
         results = PyPiRepository().search(self.argument("tokens"), flags)
 


### PR DESCRIPTION
poetry was never searching only in names.

That said, maybe name search  should be the default behavior instead of `summary` is definitively to noisy ?