### PR TITLE
Fix path resolution if poetry script is symlinked

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -195,7 +195,7 @@ import glob
 import sys
 import os
 
-lib = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "lib"))
+lib = os.path.realpath(os.path.join(os.path.realpath(__file__), "..", "..", "lib"))
 
 sys.path.insert(0, lib)
 


### PR DESCRIPTION
When poetry is symlinked (instead of sourcing the env), the path resolution resolves to the symlinked parent directory.

You can see this with a fairly simple dockerfile:

```
FROM python:3.7-alpine
RUN apk add --no-cache curl && \
    curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python && \
    ln -s $HOME/.poetry/bin/poetry /usr/local/bin
RUN poetry
```

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
