### PR TITLE
Fix CONTRIBUTING to use 'install' and not 'develop'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Now, you will need to install the required dependency for Poetry and be sure tha
 tests are passing on your machine:
 
 ```bash
-$ poetry develop
+$ poetry install
 $ poetry run pytest tests/
 ```
 


### PR DESCRIPTION
Super minor fix to the documentation. My understanding is that `develop` has been deprecated in favor of `install`.
