### PR TITLE
Include a fix for pyenv with poetry shell in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ fpath+=~/.zfunc
 ```
 
 
+## Using `poetry shell` or `poetry run` alongside `pyenv`
+
+The commonly used python version management tool [pyenv](https://github.com/pyenv/pyenv) includes, by design,
+a layer of 'shims' that allow the same commands to route to different executables
+based on configuration variables. To avoid interference between the two systems,
+you should wrap your pyenv initialization in a check for the POETRY_ACTIVE environment variable:
+
+```bash
+# Fish
+if not set -q POETRY_ACTIVE
+    set -x PATH $PYENV_ROOT/bin $PATH
+    status --is-interactive; and source (pyenv init -|psub)
+    status --is-interactive; and source (pyenv virtualenv-init -|psub)
+end
+```
+
+
 ## Introduction
 
 `poetry` is a tool to handle dependency installation as well as building and packaging of Python packages.


### PR DESCRIPTION
Please see #497, #571, #172, and possibly #198 for related issues.

In the case described by @itsthejoker here: https://github.com/sdispater/poetry/issues/497#issuecomment-437160361

a proposed solution is to have `fish` execute a script to fix $PATH after pyenv has initialized. I believe a better solution is to guard pyenv for $POETRY_ACTIVE. This PR includes documentation for this fix, as I suspect many people are hitting this roadblock.

I am not able to vouch that this fix works (or is needed) on any shells other than `fish`, but I would assume before merging you might want to include documentation for those shells.

Hopefully this is helpful!