### PR TITLE
Enhancement: add flag to show package version

### DIFF
--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -9,6 +9,7 @@ class VersionCommand(Command):
 
     version
         { version=patch }
+        {--s|show : show current version}
     """
 
     help = """\
@@ -30,6 +31,10 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
     }
 
     def handle(self):
+        if self.option("show"):
+            self.line("<info>{}</>".format(self.poetry.package.pretty_version))
+            return
+
         version = self.argument("version")
 
         version = self.increment_version(self.poetry.package.pretty_version, version)

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -9,7 +9,7 @@ class VersionCommand(Command):
 
     version
         { version=patch }
-        {--s|show : show current version}
+        {--s|show : show current version and exit}
     """
 
     help = """\

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -1,5 +1,8 @@
+from cleo import CommandTester
 import pytest
 
+from poetry import __version__
+from poetry.console import Application
 from poetry.console.commands import VersionCommand
 
 
@@ -36,3 +39,11 @@ def command():
 )
 def test_increment_version(version, rule, expected, command):
     assert expected == command.increment_version(version, rule).text
+
+
+def test_show_version(command):
+    application = Application()
+    call = application.find("version")
+    command_tester = CommandTester(call)
+    command_tester.execute([("command", command.get_name()), ("--show", True)])
+    assert command_tester.get_display().strip("\n") == __version__


### PR DESCRIPTION
# Description

This PR adds a `-s|--show` flag to `poetry version` that will print out the current package version and exit. This is useful both for manual checks and for automation as a way to easily access the version info without having to parse the `pyproject.toml` file within user code.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ✅ ] Added **tests** for changed code.
- [ ✅  ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
