### PR TITLE
Make poetry binary generated by get-poetry.py symlinkable

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -195,7 +195,7 @@ import glob
 import sys
 import os
 
-lib = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "lib"))
+lib = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "lib"))
 
 sys.path.insert(0, lib)
 


### PR DESCRIPTION
Hi,

While trying to migrate to poetry from pipenv, we have figured out that due to a bug in template code `poetry` binary generated by `get-poetry.py` is not symlinkable.

By that I mean that if you create a symlink to `poetry` binary deposited in `$HOME/.poetry/bin` in `/usr/local/bin` or, say, in your `$HOME/opt/bin` in order to avoid changing your `$PATH` for whatever reason, this will not work. The reason for this is that symlinks in `__file__` are not resolved before appending `../lib` and thus the resulting path is wrong (`/usr/local/lib` or `$HOME/opt/lib` in my example before).

I fixed this by adding one extra `realpath` call on `__file__`. I don't think tests and/or documentation changes are required. This will greatly simplify our live in CI context where we now add poetry to our Docker images and controlling environment variables like `$PATH` is difficult at scale.

Thanks!
