### PR TITLE
Html5lib catch warning

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -20,7 +20,6 @@ from typing import Generator
 from typing import Optional
 from typing import Union
 
-import html5lib
 import requests
 
 from cachecontrol import CacheControl
@@ -45,6 +44,12 @@ from poetry.version.markers import InvalidMarker
 from .auth import Auth
 from .exceptions import PackageNotFound
 from .pypi_repository import PyPiRepository
+
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import html5lib
 
 
 class Page:


### PR DESCRIPTION
This is a minor change that a) probably isn't necessary, but I thought I'd give you the option, and b) probably doesn't need any tests (and would be difficult to test in a meaningful way).

    Suppress deprecation warnings in html5lib

    html5lib currently issues a DeprecationWarning in python ^3.7. This
    warning is fixed here:

    https://github.com/html5lib/html5lib-python/commit/4f9235752cea29c5a31721440578b430823a1e69

    I have spoken with the maintainers (#whatwg on freenode) and they said
    that a new release of html5lib is not scheduled as the package is not
    actively maintained, but it sounded like they were aware of the issue
    and could release a new version. (I did not press further.)

    This is a very minor change with no major intended side effects, other
    than that it cleans up output while running tests (and presumably from
    any clients using the legacy_repository type).