### PR TITLE
Add support for 'r' build spec (#656)

### DIFF
--- a/poetry/semver/version.py
+++ b/poetry/semver/version.py
@@ -318,6 +318,10 @@ class Version(VersionRange):
 
         if build.startswith("post"):
             build = build.lstrip("post")
+        else:
+            match = re.match(r"r(\d+)$", build)
+            if match:
+                build = match.group(1)
 
         if not build:
             return

--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -21,6 +21,7 @@ from poetry.semver import VersionRange
         ("1.0.0.0", Version(1, 0, 0)),
         ("1.0.0-post", Version(1, 0, 0)),
         ("1.0.0-post1", Version(1, 0, 0, build="1")),
+        ("1.0.0-r1", Version(1, 0, 0, build="1")),
         ("0.6c", Version(0, 6, 0, pre="rc0")),
         ("0.6pre", Version(0, 6, 0, pre="rc0")),
     ],


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [] Updated **documentation** for changed code.
(n/a)

---

This PR proposes a resolution to #656 by supporting the pypi package `apsw`'s custom versioning release scheme. See also https://github.com/rogerbinns/apsw/issues/254 - the maintainer of that package has to support multiple constraints that forces them to use this versioning scheme.

As noted in #656, I am concerned that this fix may not be the correct solution. However this should resolve my specific issue.