### PR TITLE
Fix `utils.env.SystemEnv.run("python", ...` on Windows

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -429,6 +429,26 @@ class SystemEnv(Env):
     def is_venv(self):  # type: () -> bool
         return self._path != self._base
 
+    def _bin(self, bin):  # type: (str) -> str
+        """
+        Return path to the given executable.
+        """
+        bin_path = (self._bin_dir / bin).with_suffix(".exe" if self._is_windows else "")
+        if not bin_path.exists():
+            if self._is_windows and bin in (
+                "python",
+                "pythonw",
+                "python.exe",
+                "pythonw.exe",
+            ):
+                bin_path = (self._bin_dir / ".." / bin).with_suffix(".exe")
+                if not bin_path.exists():
+                    return bin
+            else:
+                return bin
+
+        return str(bin_path)
+
 
 class VirtualEnv(Env):
     """


### PR DESCRIPTION
# Pull Request Check List
Fixes the issue that `poetry` does always use the primary system interpreter on Windows when called like
`<some path>\python.exe -m poetry` and `<some path>` is not inside a virtual environment, see #655.

Maybe superseeded by PR #731.

- [ ] Added **tests** for changed code. Not sure how to test this beyond trivial unit tests as pretty specific setup involving at least two interpreters is required. 


