### PR TITLE
New env command and sub commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added an `export` command to export the lock file to other formats (only `requirements.txt` is currently supported).
 - Added a `env:info` command to get basic information about the current environment.
+- Added a `env:use` to control the Python version used by the project.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - The `debug:info` command has been renamed to `debug info`.
 - The `debug:resolve` command has been renamed to `debug resolve`.
 - The `self:update` command has been renamed to `self update`.
+- Changed the way virtualenvs are stored (names now dependent of the project's path).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 - Added an `export` command to export the lock file to other formats (only `requirements.txt` is currently supported).
-- Added a `env:info` command to get basic information about the current environment.
-- Added a `env:use` to control the Python version used by the project.
+- Added a `env info` command to get basic information about the current environment.
+- Added a `env use` command to control the Python version used by the project.
+- Added a `env list` command to list the virtualenvs associated with the current project.
+- Added a `env remove` command to delete virtualenvs associated with the current project.
 
 ### Changed
 
@@ -15,7 +17,7 @@
 - The `debug:info` command has been renamed to `debug info`.
 - The `debug:resolve` command has been renamed to `debug resolve`.
 - The `self:update` command has been renamed to `self update`.
-- Changed the way virtualenvs are stored (names now dependent of the project's path).
+- Changed the way virtualenvs are stored (names now depend on the project's path).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added an `export` command to export the lock file to other formats (only `requirements.txt` is currently supported).
+- Added a `env:info` command to get basic information about the current environment.
 
 ### Changed
 

--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -155,19 +155,44 @@ When you execute the `install` command (or any other "install" commands like `ad
 Poetry will check if it's currently inside a virtualenv and, if not, will use an existing one
 or create a brand new one for you to always work isolated from your global Python installation.
 
-!!!note
+By default, Poetry will use the currently activated Python version
+to create the virtualenv for the current project.
+    
+To easily switch between Python versions, it is recommended to
+use [pyenv](https://github.com/pyenv/pyenv) or similar tools.
+    
+For instance, if your project is Python 2.7 only, a standard workflow
+would be:
+    
+```bash
+pyenv install 2.7.15
+pyenv local 2.7.15  # Activate Python 2.7 for the current project
+poetry install
+```
 
-    To create the virtualenv for the current project, Poetry will use
-    the currently activated Python version.
+However, this might not be feasible for your system, especially Windows where `pyenv`,
+is not available. To circumvent that you can use the `env:use` command to tell
+Poetry which Python version to use for the current project.
 
-    To easily switch between Python versions, it is recommended to
-    use [pyenv](https://github.com/pyenv/pyenv) or similar tools.
+```bash
+poetry env:use /full/path/to/python
+```
 
-    For instance, if your project is Python 2.7 only, a standard workflow
-    would be:
+If you have the python executable in your `PATH` you can use it:
 
-    ```bash
-    pyenv install 2.7.15
-    pyenv local 2.7.15  # Activate Python 2.7 for the current project
-    poetry install
-    ```
+```bash
+poetry env:use python3.7
+```
+
+You can even just use the minor Python version in this case:
+
+```bash
+poetry env:use 3.7
+```
+
+If you want to disable the explicitly activated virtualenv, you can use the
+special `system` Python version to retrieve the default behavior:
+
+```bash
+poetry env:use system
+```

--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -171,28 +171,83 @@ poetry install
 ```
 
 However, this might not be feasible for your system, especially Windows where `pyenv`,
-is not available. To circumvent that you can use the `env:use` command to tell
+is not available. To circumvent that you can use the `env use` command to tell
 Poetry which Python version to use for the current project.
 
 ```bash
-poetry env:use /full/path/to/python
+poetry env use /full/path/to/python
 ```
 
 If you have the python executable in your `PATH` you can use it:
 
 ```bash
-poetry env:use python3.7
+poetry env use python3.7
 ```
 
 You can even just use the minor Python version in this case:
 
 ```bash
-poetry env:use 3.7
+poetry env use 3.7
 ```
 
 If you want to disable the explicitly activated virtualenv, you can use the
 special `system` Python version to retrieve the default behavior:
 
 ```bash
-poetry env:use system
+poetry env use system
 ```
+
+If you want to get basic information about the currently activated virtualenv,
+you can use the `env info` command:
+
+```bash
+poetry env info
+```
+
+will output something similar to this:
+
+```text
+Virtualenv
+Python:         3.7.1
+Implementation: CPython
+Path:           /path/to/poetry/cache/virtualenvs/test-O3eWbxRl-py3.7
+Valid:          True
+
+System
+Platform: darwin
+OS:       posix
+Python:   /path/to/main/python
+```
+
+If you only want to know the path to the virtualenv, you can pass the `--path` option
+to `env info`:
+
+```bash
+poetry env info --path
+```
+
+You can also list all the virtualenvs associated with the current virtualenv
+with the `env list` command:
+
+```bash
+poetry env list
+```
+
+will output something like the following:
+
+```text
+test-O3eWbxRl-py2.7
+test-O3eWbxRl-py3.6
+test-O3eWbxRl-py3.7 (Activated)
+```
+
+Finally, you can delete existing virtualenvs by using `env remove`:
+
+```bash
+poetry env remove /full/path/to/python
+poetry env remove python3.7
+poetry env remove 3.7
+poetry env remove test-O3eWbxRl-py3.7
+```
+
+If your remove the currently activated virtualenv, it will be automatically deactivated.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -375,3 +375,112 @@ poetry export -f requirements.txt
 !!!note
 
     Only the `requirements.txt` format is currently supported.
+
+## env
+
+The `env` command regroups sub commands to interact with the virtualenvs
+associated with a specific project.
+
+### env use
+
+The `env use` command tells Poetry which Python version
+to use for the current project.
+
+```bash
+poetry env use /full/path/to/python
+```
+
+If you have the python executable in your `PATH` you can use it:
+
+```bash
+poetry env use python3.7
+```
+
+You can even just use the minor Python version in this case:
+
+```bash
+poetry env use 3.7
+```
+
+If you want to disable the explicitly activated virtualenv, you can use the
+special `system` Python version to retrieve the default behavior:
+
+```bash
+poetry env use system
+```
+
+### env info
+
+The `env info` command displays basic information about the currently activated virtualenv:
+
+```bash
+poetry env info
+```
+
+will output something similar to this:
+
+```text
+Virtualenv
+Python:         3.7.1
+Implementation: CPython
+Path:           /path/to/poetry/cache/virtualenvs/test-O3eWbxRl-py3.7
+Valid:          True
+
+System
+Platform: darwin
+OS:       posix
+Python:   /path/to/main/python
+```
+
+If you only want to know the path to the virtualenv, you can pass the `--path` option
+to `env info`:
+
+```bash
+poetry env info --path
+```
+
+#### Options
+
+* `--path`: Only display the path of the virtualenv.
+
+
+### env list
+
+The `env list` command lists all the virtualenvs associated with the current virtualenv.
+
+```bash
+poetry env list
+```
+
+will output something like the following:
+
+```text
+test-O3eWbxRl-py2.7
+test-O3eWbxRl-py3.6
+test-O3eWbxRl-py3.7 (Activated)
+```
+
+#### Options
+
+* `--full-path`: Display the full path of the virtualenvs.
+
+### env remove
+
+The `env remove` command deletes virtualenvs associated with the current project:
+
+```bash
+poetry env remove /full/path/to/python
+```
+
+Similarly to `env use`, you can either pass `python3.7`, `3.7` or the name of
+the virtualenv (as returned by `env list`):
+
+```bash
+poetry env remove python3.7
+poetry env remove 3.7
+poetry env remove test-O3eWbxRl-py3.7
+```
+
+!!!note
+
+    If your remove the currently activated virtualenv, it will be automatically deactivated.

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -33,6 +33,8 @@ from .commands.self import SelfCommand
 
 from .config import ApplicationConfig
 
+from .commands.env import EnvCommand
+
 
 class Application(BaseApplication):
     def __init__(self):
@@ -88,6 +90,9 @@ class Application(BaseApplication):
 
         # Debug command
         commands += [DebugCommand()]
+
+        # Env command
+        commands += [EnvCommand()]
 
         # Self commands
         commands += [SelfCommand()]

--- a/poetry/console/commands/debug/info.py
+++ b/poetry/console/commands/debug/info.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from clikit.args import StringArgs
+
 from ..command import Command
 
 
@@ -25,41 +27,7 @@ class DebugInfoCommand(Command):
         self.line("<info>Version</info>: <comment>{}</>".format(poetry.VERSION))
         self.line("<info>Python</info>:  <comment>{}</>".format(poetry_python_version))
 
-        self.line("")
+        args = StringArgs("")
+        command = self.application.get_command("env").get_sub_command("info")
 
-        env_python_version = ".".join(str(s) for s in env.version_info[:3])
-        self.line("<b>Virtualenv</b>")
-        self.line("")
-        listing = [
-            "<info>Python</info>:         <comment>{}</>".format(env_python_version),
-            "<info>Implementation</info>: <comment>{}</>".format(
-                env.python_implementation
-            ),
-            "<info>Path</info>:           <comment>{}</>".format(
-                env.path if env.is_venv() else "NA"
-            ),
-        ]
-        if env.is_venv():
-            listing.append(
-                "<info>Valid</info>:          <{tag}>{is_valid}</{tag}>".format(
-                    tag="comment" if env.is_sane() else "error", is_valid=env.is_sane()
-                )
-            )
-
-        for line in listing:
-            self.line(line)
-
-        self.line("")
-
-        self.line("<b>System</b>")
-        self.line("")
-        listing = [
-            "<info>Platform</info>: <comment>{}</>".format(sys.platform),
-            "<info>OS</info>:       <comment>{}</>".format(os.name),
-            "<info>Python</info>:   <comment>{}</>".format(env.base),
-        ]
-
-        for line in listing:
-            self.line(line)
-
-        self.line("")
+        return command.run(args, self._io)

--- a/poetry/console/commands/debug/info.py
+++ b/poetry/console/commands/debug/info.py
@@ -14,19 +14,20 @@ class DebugInfoCommand(Command):
     """
 
     def handle(self):
-        from ....utils.env import Env
-
-        poetry = self.poetry
-        env = Env.get(poetry.file.parent)
-
         poetry_python_version = ".".join(str(s) for s in sys.version_info[:3])
 
         self.line("")
         self.line("<b>Poetry</b>")
-        self.line("")
-        self.line("<info>Version</info>: <comment>{}</>".format(poetry.VERSION))
-        self.line("<info>Python</info>:  <comment>{}</>".format(poetry_python_version))
-
+        self.line(
+            "\n".join(
+                [
+                    "<info>Version</info>: <comment>{}</>".format(self.poetry.VERSION),
+                    "<info>Python</info>:  <comment>{}</>".format(
+                        poetry_python_version
+                    ),
+                ]
+            )
+        )
         args = StringArgs("")
         command = self.application.get_command("env").get_sub_command("info")
 

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -24,7 +24,7 @@ class DebugResolveCommand(Command):
         from poetry.puzzle import Solver
         from poetry.repositories.repository import Repository
         from poetry.semver import parse_constraint
-        from poetry.utils.env import Env
+        from poetry.utils.env import EnvManager
 
         packages = self.argument("package")
 
@@ -78,7 +78,7 @@ class DebugResolveCommand(Command):
 
             return 0
 
-        env = Env.get(self.poetry.file.parent)
+        env = EnvManager(self.poetry.config).get(self.poetry.file.parent)
         current_python_version = parse_constraint(
             ".".join(str(v) for v in env.version_info)
         )

--- a/poetry/console/commands/env/__init__.py
+++ b/poetry/console/commands/env/__init__.py
@@ -1,0 +1,1 @@
+from .env import EnvCommand

--- a/poetry/console/commands/env/env.py
+++ b/poetry/console/commands/env/env.py
@@ -1,0 +1,16 @@
+from ..command import Command
+
+from .info import EnvInfoCommand
+
+
+class EnvCommand(Command):
+    """
+    Interact with Poetry's project environments.
+
+    env
+    """
+
+    commands = [EnvInfoCommand()]
+
+    def handle(self):  # type: () -> int
+        return self.call("help", self._config.name)

--- a/poetry/console/commands/env/env.py
+++ b/poetry/console/commands/env/env.py
@@ -1,6 +1,7 @@
 from ..command import Command
 
 from .info import EnvInfoCommand
+from .list import EnvListCommand
 from .use import EnvUseCommand
 
 
@@ -11,7 +12,7 @@ class EnvCommand(Command):
     env
     """
 
-    commands = [EnvInfoCommand(), EnvUseCommand()]
+    commands = [EnvInfoCommand(), EnvListCommand(), EnvUseCommand()]
 
     def handle(self):  # type: () -> int
         return self.call("help", self._config.name)

--- a/poetry/console/commands/env/env.py
+++ b/poetry/console/commands/env/env.py
@@ -1,6 +1,7 @@
 from ..command import Command
 
 from .info import EnvInfoCommand
+from .use import EnvUseCommand
 
 
 class EnvCommand(Command):
@@ -10,7 +11,7 @@ class EnvCommand(Command):
     env
     """
 
-    commands = [EnvInfoCommand()]
+    commands = [EnvInfoCommand(), EnvUseCommand()]
 
     def handle(self):  # type: () -> int
         return self.call("help", self._config.name)

--- a/poetry/console/commands/env/env.py
+++ b/poetry/console/commands/env/env.py
@@ -2,6 +2,7 @@ from ..command import Command
 
 from .info import EnvInfoCommand
 from .list import EnvListCommand
+from .remove import EnvRemoveCommand
 from .use import EnvUseCommand
 
 
@@ -12,7 +13,7 @@ class EnvCommand(Command):
     env
     """
 
-    commands = [EnvInfoCommand(), EnvListCommand(), EnvUseCommand()]
+    commands = [EnvInfoCommand(), EnvListCommand(), EnvRemoveCommand(), EnvUseCommand()]
 
     def handle(self):  # type: () -> int
         return self.call("help", self._config.name)

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -10,10 +10,10 @@ class EnvInfoCommand(Command):
     """
 
     def handle(self):
-        from poetry.utils.env import Env
+        from poetry.utils.env import EnvManager
 
         poetry = self.poetry
-        env = Env.get(cwd=poetry.file.parent)
+        env = EnvManager(poetry.config).get(cwd=poetry.file.parent)
 
         if self.option("path"):
             if not env.is_venv():

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -1,0 +1,60 @@
+from ..command import Command
+
+
+class EnvInfoCommand(Command):
+    """
+    Display information about the current environment.
+
+    info
+        {--p|path : Only display the environment's path}
+    """
+
+    def handle(self):
+        from poetry.utils.env import Env
+
+        poetry = self.poetry
+        env = Env.get(cwd=poetry.file.parent)
+
+        if self.option("path"):
+            if not env.is_venv():
+                return 1
+
+            self.write(str(env.path))
+
+            return
+
+        self._display_complete_info(env)
+
+    def _display_complete_info(self, env):
+        env_python_version = ".".join(str(s) for s in env.version_info[:3])
+        self.line("")
+        self.line("<b>Virtualenv</b>")
+        listing = [
+            "<info>Python</info>:         <comment>{}</>".format(env_python_version),
+            "<info>Implementation</info>: <comment>{}</>".format(
+                env.python_implementation
+            ),
+            "<info>Path</info>:           <comment>{}</>".format(
+                env.path if env.is_venv() else "NA"
+            ),
+        ]
+        if env.is_venv():
+            listing.append(
+                "<info>Valid</info>:          <{tag}>{is_valid}</{tag}>".format(
+                    tag="comment" if env.is_sane() else "error", is_valid=env.is_sane()
+                )
+            )
+        self.line("\n".join(listing))
+
+        self.line("")
+
+        self.line("<b>System</b>")
+        self.line(
+            "\n".join(
+                [
+                    "<info>Platform</info>: <comment>{}</>".format(env.platform),
+                    "<info>OS</info>:       <comment>{}</>".format(env.os),
+                    "<info>Python</info>:   <comment>{}</>".format(env.base),
+                ]
+            )
+        )

--- a/poetry/console/commands/env/list.py
+++ b/poetry/console/commands/env/list.py
@@ -1,0 +1,29 @@
+from ..command import Command
+
+
+class EnvListCommand(Command):
+    """
+    List all virtualenvs associated with the current project.
+
+    list
+        {--full-path : Output the full paths of the virtualenvs}
+    """
+
+    def handle(self):
+        from poetry.utils.env import EnvManager
+
+        poetry = self.poetry
+        manager = EnvManager(poetry.config)
+        current_env = manager.get(self.poetry.file.parent)
+
+        for venv in manager.list(self.poetry.file.parent):
+            name = venv.path.name
+            if self.option("full-path"):
+                name = str(venv.path)
+
+            if venv == current_env:
+                self.line("<info>{} (Activated)</info>".format(name))
+
+                continue
+
+            self.line(name)

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -1,0 +1,19 @@
+from ..command import Command
+
+
+class EnvRemoveCommand(Command):
+    """
+    Remove a specific virtualenv associated with the project.
+
+    remove
+        {python : The python executable to remove the virtualenv for.}
+    """
+
+    def handle(self):
+        from poetry.utils.env import EnvManager
+
+        poetry = self.poetry
+        manager = EnvManager(poetry.config)
+        venv = manager.remove(self.argument("python"), poetry.file.parent)
+
+        self.line("Deleted virtualenv: <comment>{}</comment>".format(venv.path))

--- a/poetry/console/commands/env/use.py
+++ b/poetry/console/commands/env/use.py
@@ -1,0 +1,25 @@
+from ..command import Command
+
+
+class EnvUseCommand(Command):
+    """
+    Activate or create a new virtualenv for the current project.
+
+    use
+        {python : The python executable to use.}
+    """
+
+    def handle(self):
+        from poetry.utils.env import EnvManager
+
+        poetry = self.poetry
+        manager = EnvManager(poetry.config)
+
+        if self.argument("python") == "system":
+            manager.deactivate(poetry.file.parent, self._io)
+
+            return
+
+        env = manager.activate(self.argument("python"), poetry.file.parent, self._io)
+
+        self.line("Using virtualenv: <comment>{}</>".format(env.path))

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -37,7 +37,7 @@ The <info>init</info> command creates a basic <comment>pyproject.toml</> file in
     def handle(self):
         from poetry.layouts import layout
         from poetry.utils._compat import Path
-        from poetry.utils.env import Env
+        from poetry.utils.env import EnvManager
         from poetry.vcs.git import GitConfig
 
         if (Path.cwd() / "pyproject.toml").exists():
@@ -100,7 +100,7 @@ The <info>init</info> command creates a basic <comment>pyproject.toml</> file in
         question.set_validator(self._validate_license)
         license = self.ask(question)
 
-        current_env = Env.get(Path.cwd())
+        current_env = EnvManager().get(Path.cwd())
         default_python = "^{}".format(
             ".".join(str(v) for v in current_env.version_info[:2])
         )

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -14,7 +14,7 @@ class NewCommand(Command):
     def handle(self):
         from poetry.layouts import layout
         from poetry.utils._compat import Path
-        from poetry.utils.env import Env
+        from poetry.utils.env import EnvManager
         from poetry.vcs.git import GitConfig
 
         if self.option("src"):
@@ -45,7 +45,7 @@ class NewCommand(Command):
             if author_email:
                 author += " <{}>".format(author_email)
 
-        current_env = Env.get(Path.cwd())
+        current_env = EnvManager().get(Path.cwd())
         default_python = "^{}".format(
             ".".join(str(v) for v in current_env.version_info[:2])
         )

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -30,7 +30,7 @@ from poetry.utils._compat import PY35
 from poetry.utils._compat import Path
 from poetry.utils.helpers import parse_requires
 from poetry.utils.helpers import safe_rmtree
-from poetry.utils.env import Env
+from poetry.utils.env import EnvManager
 from poetry.utils.env import EnvCommandError
 from poetry.utils.setup_reader import SetupReader
 
@@ -260,7 +260,7 @@ class Provider:
 
             try:
                 cwd = dependency.full_path
-                venv = Env.get(cwd)
+                venv = EnvManager().get(cwd)
                 venv.run("python", "setup.py", "egg_info")
             except EnvCommandError:
                 result = SetupReader.read_from_directory(dependency.full_path)

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -154,6 +154,14 @@ class Env(object):
         """
         return self._bin("pip")
 
+    @property
+    def platform(self):  # type: () -> str
+        return sys.platform
+
+    @property
+    def os(self):  # type: () -> str
+        return os.name
+
     @classmethod
     def get(cls, cwd, reload=False):  # type: (Path, bool) -> Env
         if cls._env is not None and not reload:

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -187,10 +187,7 @@ class EnvManager(object):
                 current_minor = current_env["minor"]
                 current_patch = current_env["patch"]
 
-                if current_minor != minor:
-                    # We need to activate and/or create
-                    create = True
-                elif current_patch != patch:
+                if current_minor == minor and current_patch != patch:
                     # We need to recreate
                     create = True
 
@@ -200,8 +197,16 @@ class EnvManager(object):
         # Create if needed
         if not venv.exists() or venv.exists() and create:
             in_venv = os.environ.get("VIRTUAL_ENV") is not None
-            if in_venv:
+            if in_venv or not venv.exists():
                 create = True
+
+            if venv.exists():
+                # We need to check if the patch version is correct
+                _venv = VirtualEnv(venv)
+                current_patch = ".".join(str(v) for v in _venv.version_info[:3])
+
+                if patch != current_patch:
+                    create = True
 
             self.create_venv(cwd, io, executable=python, force=create)
 

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1,10 +1,13 @@
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import sysconfig
 import warnings
+
+import tomlkit
 
 from contextlib import contextmanager
 from subprocess import CalledProcessError
@@ -17,10 +20,12 @@ from clikit.api.io import IO
 
 from poetry.config import Config
 from poetry.locations import CACHE_DIR
+from poetry.semver import Version
 from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils._compat import list_to_shell_command
+from poetry.utils.toml_file import TomlFile
 from poetry.version.markers import BaseMarker
 
 
@@ -84,6 +89,22 @@ import sys
 print('.'.join([str(s) for s in sys.version_info[:3]]))
 """
 
+CREATE_VENV_COMMAND = """\
+path = {!r}
+
+try:
+    from venv import EnvBuilder
+
+    builder = EnvBuilder(with_pip=True)
+    build = builder.create
+except ImportError:
+    # We fallback on virtualenv for Python 2.7
+    from virtualenv import create_environment
+
+    build = create_environment
+
+build(path)"""
+
 
 class EnvError(Exception):
 
@@ -99,12 +120,307 @@ class EnvCommandError(EnvError):
         super(EnvCommandError, self).__init__(message)
 
 
+class EnvManager(object):
+    """
+    Environments manager
+    """
+
+    _env = None
+
+    ENVS_FILE = "envs.toml"
+
+    def __init__(self, config=None):  # type: (Config) -> None
+        if config is None:
+            config = Config.create("config.toml")
+
+        self._config = config
+
+    def activate(self, python, cwd, io):  # type: (str, Optional[Path], IO) -> Env
+        venv_path = self._config.setting("settings.virtualenvs.path")
+        if venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        envs_file = TomlFile(venv_path / self.ENVS_FILE)
+
+        try:
+            python_version = Version.parse(python)
+            python = "python{}".format(python_version.major)
+            if python_version.precision > 1:
+                python += ".{}".format(python_version.minor)
+        except ValueError:
+            # Executable in PATH or full executable path
+            pass
+
+        try:
+            python_version = decode(
+                subprocess.check_output(
+                    " ".join(
+                        [
+                            python,
+                            "-c",
+                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
+                        ]
+                    ),
+                    shell=True,
+                )
+            )
+        except CalledProcessError as e:
+            raise EnvCommandError(e)
+
+        python_version = Version.parse(python_version.strip())
+        minor = "{}.{}".format(python_version.major, python_version.minor)
+        patch = python_version.text
+
+        create = False
+        envs = tomlkit.document()
+        if envs_file.exists():
+            envs = envs_file.read()
+            current_env = envs.get(cwd.name)
+            if current_env is not None:
+                current_minor = current_env["minor"]
+                current_patch = current_env["patch"]
+
+                if current_minor != minor:
+                    # We need to activate and/or create
+                    create = True
+                elif current_patch != patch:
+                    # We need to recreate
+                    create = True
+
+        name = cwd.name
+        name = "{}-py{}".format(name, minor)
+
+        venv = venv_path / name
+
+        # Create if needed
+        if not venv.exists() or venv.exists() and create:
+            self.create_venv(cwd, io, executable=python, force=create)
+
+        # Activate
+        envs[cwd.name] = {"minor": minor, "patch": patch}
+        envs_file.write(envs)
+
+        return self.get(cwd, reload=True)
+
+    def deactivate(self, cwd, io):  # type: (Optional[Path], IO) -> None
+        venv_path = self._config.setting("settings.virtualenvs.path")
+        if venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        name = cwd.name
+
+        envs_file = TomlFile(venv_path / self.ENVS_FILE)
+        if envs_file.exists():
+            envs = envs_file.read()
+            env = envs.get(cwd.name)
+            if env is not None:
+                io.write_line(
+                    "Deactivating virtualenv: <comment>{}</comment>".format(
+                        venv_path / (name + "-py{}".format(env["minor"]))
+                    )
+                )
+                del envs[cwd.name]
+
+                envs_file.write(envs)
+
+    def get(self, cwd, reload=False):  # type: (Path, bool) -> Env
+        if self._env is not None and not reload:
+            return self._env
+
+        python_minor = ".".join([str(v) for v in sys.version_info[:2]])
+
+        venv_path = self._config.setting("settings.virtualenvs.path")
+        if venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        envs_file = TomlFile(venv_path / self.ENVS_FILE)
+        env = None
+        if envs_file.exists():
+            envs = envs_file.read()
+            env = envs.get(cwd.name)
+            if env:
+                python_minor = env["minor"]
+
+        # Check if we are inside a virtualenv or not
+        in_venv = os.environ.get("VIRTUAL_ENV") is not None
+
+        if not in_venv or env is not None:
+            # Checking if a local virtualenv exists
+            if (cwd / ".venv").exists():
+                venv = cwd / ".venv"
+
+                return VirtualEnv(venv)
+
+            create_venv = self._config.setting("settings.virtualenvs.create", True)
+
+            if not create_venv:
+                return SystemEnv(Path(sys.prefix))
+
+            venv_path = self._config.setting("settings.virtualenvs.path")
+            if venv_path is None:
+                venv_path = Path(CACHE_DIR) / "virtualenvs"
+            else:
+                venv_path = Path(venv_path)
+
+            name = cwd.name
+            name = "{}-py{}".format(name, python_minor)
+
+            venv = venv_path / name
+
+            if not venv.exists():
+                return SystemEnv(Path(sys.prefix))
+
+            return VirtualEnv(venv)
+
+        if os.environ.get("VIRTUAL_ENV") is not None:
+            prefix = Path(os.environ["VIRTUAL_ENV"])
+            base_prefix = None
+        else:
+            prefix = Path(sys.prefix)
+            base_prefix = self.get_base_prefix()
+
+        return VirtualEnv(prefix, base_prefix)
+
+    def create_venv(
+        self, cwd, io, name=None, executable=None, force=False
+    ):  # type: (Path, IO, Optional[str], Optional[str], bool) -> Env
+        if self._env is not None:
+            return self._env
+
+        env = self.get(cwd, reload=True)
+        if env.is_venv() and not force:
+            # Already inside a virtualenv.
+            return env
+
+        create_venv = self._config.setting("settings.virtualenvs.create")
+        root_venv = self._config.setting("settings.virtualenvs.in-project")
+
+        venv_path = self._config.setting("settings.virtualenvs.path")
+        if root_venv:
+            venv_path = cwd / ".venv"
+        elif venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        if not name:
+            name = cwd.name
+
+        python_minor = ".".join([str(v) for v in sys.version_info[:2]])
+        if executable:
+            python_minor = decode(
+                subprocess.check_output(
+                    " ".join(
+                        [
+                            executable,
+                            "-c",
+                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:2]]))\"",
+                        ]
+                    ),
+                    shell=True,
+                )
+            )
+
+        name = "{}-py{}".format(name, python_minor.strip())
+
+        if root_venv:
+            venv = venv_path
+        else:
+            venv = venv_path / name
+
+        if not venv.exists():
+            if create_venv is False:
+                io.write_line(
+                    "<fg=black;bg=yellow>"
+                    "Skipping virtualenv creation, "
+                    "as specified in config file."
+                    "</>"
+                )
+
+                return SystemEnv(Path(sys.prefix))
+
+            io.write_line(
+                "Creating virtualenv <info>{}</> in {}".format(name, str(venv_path))
+            )
+
+            self.build_venv(str(venv), executable=executable)
+        else:
+            if force:
+                io.write_line(
+                    "Recreating virtualenv <info>{}</> in {}".format(name, str(venv))
+                )
+                self.remove_venv(str(venv))
+                self.build_venv(str(venv), executable=executable)
+            elif io.is_very_verbose():
+                io.write_line("Virtualenv <info>{}</> already exists.".format(name))
+
+        # venv detection:
+        # stdlib venv may symlink sys.executable, so we can't use realpath.
+        # but others can symlink *to* the venv Python,
+        # so we can't just use sys.executable.
+        # So we just check every item in the symlink tree (generally <= 3)
+        p = os.path.normcase(sys.executable)
+        paths = [p]
+        while os.path.islink(p):
+            p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
+            paths.append(p)
+
+        p_venv = os.path.normcase(str(venv))
+        if any(p.startswith(p_venv) for p in paths):
+            # Running properly in the virtualenv, don't need to do anything
+            return SystemEnv(Path(sys.prefix), self.get_base_prefix())
+
+        return VirtualEnv(venv)
+
+    def build_venv(self, path, executable=None):
+        if executable is not None:
+            # Create virtualenv by using an external executable
+            try:
+                p = subprocess.Popen(
+                    " ".join([executable, "-"]), stdin=subprocess.PIPE, shell=True
+                )
+                p.communicate(encode(CREATE_VENV_COMMAND.format(path)))
+            except CalledProcessError as e:
+                raise EnvCommandError(e)
+
+            return
+
+        try:
+            from venv import EnvBuilder
+
+            builder = EnvBuilder(with_pip=True)
+            build = builder.create
+        except ImportError:
+            # We fallback on virtualenv for Python 2.7
+            from virtualenv import create_environment
+
+            build = create_environment
+
+        build(path)
+
+    def remove_venv(self, path):  # type: (str) -> None
+        shutil.rmtree(path)
+
+    def get_base_prefix(self):  # type: () -> Path
+        if hasattr(sys, "real_prefix"):
+            return sys.real_prefix
+
+        if hasattr(sys, "base_prefix"):
+            return sys.base_prefix
+
+        return sys.prefix
+
+
 class Env(object):
     """
     An abstract Python environment.
     """
-
-    _env = None
 
     def __init__(self, path, base=None):  # type: (Path, Optional[Path]) -> None
         self._is_windows = sys.platform == "win32"
@@ -161,140 +477,6 @@ class Env(object):
     @property
     def os(self):  # type: () -> str
         return os.name
-
-    @classmethod
-    def get(cls, cwd, reload=False):  # type: (Path, bool) -> Env
-        if cls._env is not None and not reload:
-            return cls._env
-
-        # Check if we are inside a virtualenv or not
-        in_venv = os.environ.get("VIRTUAL_ENV") is not None
-
-        if not in_venv:
-            # Checking if a local virtualenv exists
-            if (cwd / ".venv").exists():
-                venv = cwd / ".venv"
-
-                return VirtualEnv(venv)
-
-            config = Config.create("config.toml")
-            create_venv = config.setting("settings.virtualenvs.create", True)
-
-            if not create_venv:
-                return SystemEnv(Path(sys.prefix))
-
-            venv_path = config.setting("settings.virtualenvs.path")
-            if venv_path is None:
-                venv_path = Path(CACHE_DIR) / "virtualenvs"
-            else:
-                venv_path = Path(venv_path)
-
-            name = cwd.name
-            name = "{}-py{}".format(
-                name, ".".join([str(v) for v in sys.version_info[:2]])
-            )
-
-            venv = venv_path / name
-
-            if not venv.exists():
-                return SystemEnv(Path(sys.prefix))
-
-            return VirtualEnv(venv)
-
-        if os.environ.get("VIRTUAL_ENV") is not None:
-            prefix = Path(os.environ["VIRTUAL_ENV"])
-            base_prefix = None
-        else:
-            prefix = Path(sys.prefix)
-            base_prefix = cls.get_base_prefix()
-
-        return VirtualEnv(prefix, base_prefix)
-
-    @classmethod
-    def create_venv(cls, cwd, io, name=None):  # type: (Path, IO, bool) -> Env
-        if cls._env is not None:
-            return cls._env
-
-        env = cls.get(cwd)
-        if env.is_venv():
-            # Already inside a virtualenv.
-            return env
-
-        config = Config.create("config.toml")
-
-        create_venv = config.setting("settings.virtualenvs.create")
-        root_venv = config.setting("settings.virtualenvs.in-project")
-
-        venv_path = config.setting("settings.virtualenvs.path")
-        if root_venv:
-            venv_path = cwd / ".venv"
-        elif venv_path is None:
-            venv_path = Path(CACHE_DIR) / "virtualenvs"
-        else:
-            venv_path = Path(venv_path)
-
-        if not name:
-            name = cwd.name
-
-        name = "{}-py{}".format(name, ".".join([str(v) for v in sys.version_info[:2]]))
-
-        if root_venv:
-            venv = venv_path
-        else:
-            venv = venv_path / name
-
-        if not venv.exists():
-            if create_venv is False:
-                io.write_line(
-                    "<fg=black;bg=yellow>"
-                    "Skipping virtualenv creation, "
-                    "as specified in config file."
-                    "</>"
-                )
-
-                return SystemEnv(Path(sys.prefix))
-
-            io.write_line(
-                "Creating virtualenv <info>{}</> in {}".format(name, str(venv_path))
-            )
-
-            cls.build_venv(str(venv))
-        else:
-            if io.is_very_verbose():
-                io.write_line("Virtualenv <info>{}</> already exists.".format(name))
-
-        # venv detection:
-        # stdlib venv may symlink sys.executable, so we can't use realpath.
-        # but others can symlink *to* the venv Python,
-        # so we can't just use sys.executable.
-        # So we just check every item in the symlink tree (generally <= 3)
-        p = os.path.normcase(sys.executable)
-        paths = [p]
-        while os.path.islink(p):
-            p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
-            paths.append(p)
-
-        p_venv = os.path.normcase(str(venv))
-        if any(p.startswith(p_venv) for p in paths):
-            # Running properly in the virtualenv, don't need to do anything
-            return SystemEnv(Path(sys.prefix), cls.get_base_prefix())
-
-        return VirtualEnv(venv)
-
-    @classmethod
-    def build_venv(cls, path):
-        try:
-            from venv import EnvBuilder
-
-            builder = EnvBuilder(with_pip=True)
-            build = builder.create
-        except ImportError:
-            # We fallback on virtualenv for Python 2.7
-            from virtualenv import create_environment
-
-            build = create_environment
-
-        build(path)
 
     @classmethod
     def get_base_prefix(cls):  # type: () -> Path

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from subprocess import CalledProcessError
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Tuple
 
@@ -293,6 +294,23 @@ class EnvManager(object):
             base_prefix = self.get_base_prefix()
 
         return VirtualEnv(prefix, base_prefix)
+
+    def list(self, cwd, name=None):  # type: (Path, Optional[str]) -> List[VirtualEnv]
+        if name is None:
+            name = cwd.name
+
+        venv_name = self.generate_env_name(name, str(cwd))
+
+        venv_path = self._config.setting("settings.virtualenvs.path")
+        if venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        return [
+            VirtualEnv(Path(p))
+            for p in sorted(venv_path.glob("{}-py*".format(venv_name)))
+        ]
 
     def create_venv(
         self, cwd, io, name=None, executable=None, force=False
@@ -580,6 +598,9 @@ class Env(object):
             return bin
 
         return str(bin_path)
+
+    def __eq__(self, other):  # type: (Env) -> bool
+        return other.__class__ == self.__class__ and other.path == self.path
 
     def __repr__(self):
         return '{}("{}")'.format(self.__class__.__name__, self._path)

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -198,6 +198,10 @@ class EnvManager(object):
 
         # Create if needed
         if not venv.exists() or venv.exists() and create:
+            in_venv = os.environ.get("VIRTUAL_ENV") is not None
+            if in_venv:
+                create = True
+
             self.create_venv(cwd, io, executable=python, force=create)
 
         # Activate
@@ -293,7 +297,7 @@ class EnvManager(object):
     def create_venv(
         self, cwd, io, name=None, executable=None, force=False
     ):  # type: (Path, IO, Optional[str], Optional[str], bool) -> Env
-        if self._env is not None:
+        if self._env is not None and not force:
             return self._env
 
         env = self.get(cwd, reload=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,15 @@ def mock_clone(_, source, dest):
 
 
 @pytest.fixture
+def tmp_dir():
+    dir_ = tempfile.mkdtemp(prefix="poetry_")
+
+    yield dir_
+
+    shutil.rmtree(dir_)
+
+
+@pytest.fixture
 def environ():
     original_environ = os.environ
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,11 +57,12 @@ def tmp_dir():
 
 @pytest.fixture
 def environ():
-    original_environ = os.environ
+    original_environ = dict(os.environ)
 
-    yield os.environ
+    yield
 
-    os.environ = original_environ
+    os.environ.clear()
+    os.environ.update(original_environ)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -1,4 +1,19 @@
+import pytest
+
 from cleo.testers import CommandTester
+
+from poetry.utils._compat import Path
+from poetry.utils.env import MockEnv
+
+
+@pytest.fixture(autouse=True)
+def setup(mocker):
+    mocker.patch(
+        "poetry.utils.env.EnvManager.get",
+        return_value=MockEnv(
+            path=Path("/prefix"), base=Path("/base/prefix"), is_venv=True
+        ),
+    )
 
 
 def test_env_info_displays_complete_info(app):
@@ -13,7 +28,7 @@ Virtualenv
 
  * Python:         3.7.0
  * Implementation: CPython
- * Path:           /prefix
+ * Path:           {prefix}
  * Valid:          True
 
 
@@ -22,9 +37,11 @@ System
 
  * Platform: darwin
  * OS:       posix
- * Python:   /base/prefix
+ * Python:   {base_prefix}
 
-"""
+""".format(
+        prefix=str(Path("/prefix")), base_prefix=str(Path("/base/prefix"))
+    )
 
     assert tester.get_display(True) == expected
 
@@ -35,6 +52,6 @@ def test_env_info_displays_path_only(app):
 
     tester.execute([("command", command.get_name()), ("--path", True)])
 
-    expected = """/prefix"""
+    expected = str(Path("/prefix"))
 
     assert tester.get_display(True) == expected

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -29,7 +29,7 @@ System
     assert tester.get_display(True) == expected
 
 
-def test_env_info_displays_path_onlyo(app):
+def test_env_info_displays_path_only(app):
     command = app.find("env:info")
     tester = CommandTester(command)
 

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -1,0 +1,40 @@
+from cleo.testers import CommandTester
+
+
+def test_env_info_displays_complete_info(app):
+    command = app.find("env:info")
+    tester = CommandTester(command)
+
+    tester.execute([("command", command.get_name())])
+
+    expected = """
+Virtualenv
+==========
+
+ * Python:         3.7.0
+ * Implementation: CPython
+ * Path:           /prefix
+ * Valid:          True
+
+
+System
+======
+
+ * Platform: darwin
+ * OS:       posix
+ * Python:   /base/prefix
+
+"""
+
+    assert tester.get_display(True) == expected
+
+
+def test_env_info_displays_path_onlyo(app):
+    command = app.find("env:info")
+    tester = CommandTester(command)
+
+    tester.execute([("command", command.get_name()), ("--path", True)])
+
+    expected = """/prefix"""
+
+    assert tester.get_display(True) == expected

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -17,41 +17,35 @@ def setup(mocker):
 
 
 def test_env_info_displays_complete_info(app):
-    command = app.find("env:info")
+    command = app.find("env info")
     tester = CommandTester(command)
 
-    tester.execute([("command", command.get_name())])
+    tester.execute()
 
     expected = """
 Virtualenv
-==========
-
- * Python:         3.7.0
- * Implementation: CPython
- * Path:           {prefix}
- * Valid:          True
-
+Python:         3.7.0
+Implementation: CPython
+Path:           {prefix}
+Valid:          True
 
 System
-======
-
- * Platform: darwin
- * OS:       posix
- * Python:   {base_prefix}
-
+Platform: darwin
+OS:       posix
+Python:   {base_prefix}
 """.format(
         prefix=str(Path("/prefix")), base_prefix=str(Path("/base/prefix"))
     )
 
-    assert tester.get_display(True) == expected
+    assert expected == tester.io.fetch_output()
 
 
 def test_env_info_displays_path_only(app):
-    command = app.find("env:info")
+    command = app.find("env info")
     tester = CommandTester(command)
 
-    tester.execute([("command", command.get_name()), ("--path", True)])
+    tester.execute("--path")
 
     expected = str(Path("/prefix"))
 
-    assert tester.get_display(True) == expected
+    assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_list.py
+++ b/tests/console/commands/env/test_list.py
@@ -1,0 +1,62 @@
+import tomlkit
+
+from cleo.testers import CommandTester
+
+from poetry.utils._compat import Path
+from poetry.utils.env import EnvManager
+from poetry.utils.toml_file import TomlFile
+
+
+def test_none_activated(app, tmp_dir, config):
+    app.poetry._config = config
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+
+    command = app.find("env list")
+    tester = CommandTester(command)
+    tester.execute()
+
+    expected = """\
+{}-py3.6
+{}-py3.7
+""".format(
+        venv_name, venv_name
+    )
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_activated(app, tmp_dir, config):
+    app.poetry._config = config
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
+    envs_file.write(doc)
+
+    command = app.find("env list")
+    tester = CommandTester(command)
+    tester.execute()
+
+    expected = """\
+{}-py3.6
+{}-py3.7 (Activated)
+""".format(
+        venv_name, venv_name
+    )
+
+    assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -1,0 +1,65 @@
+from cleo.testers import CommandTester
+
+from poetry.utils._compat import Path
+from poetry.utils.env import EnvManager
+
+from .test_use import Version
+from .test_use import check_output_wrapper
+
+
+def test_remove_by_python_version(app, tmp_dir, config, mocker):
+    app.poetry._config = config
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+
+    mocker.patch(
+        "subprocess.check_output",
+        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+    )
+
+    command = app.find("env remove")
+    tester = CommandTester(command)
+    tester.execute("3.6")
+
+    assert not (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+
+    expected = "Deleted virtualenv: {}\n".format(
+        (Path(tmp_dir) / "{}-py3.6".format(venv_name))
+    )
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_remove_by_name(app, tmp_dir, config, mocker):
+    app.poetry._config = config
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+
+    mocker.patch(
+        "subprocess.check_output",
+        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+    )
+
+    command = app.find("env remove")
+    tester = CommandTester(command)
+    tester.execute("{}-py3.6".format(venv_name))
+
+    assert not (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+
+    expected = "Deleted virtualenv: {}\n".format(
+        (Path(tmp_dir) / "{}-py3.6".format(venv_name))
+    )
+
+    assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -1,0 +1,124 @@
+import os
+import shutil
+import sys
+
+import tomlkit
+
+from cleo.testers import CommandTester
+
+from poetry.semver import Version
+from poetry.utils._compat import Path
+from poetry.utils.env import EnvManager
+from poetry.utils.env import MockEnv
+from poetry.utils.toml_file import TomlFile
+
+
+CWD = Path(__file__).parent.parent / "fixtures" / "simple_project"
+
+
+def build_venv(path, executable=None):
+    os.mkdir(path)
+
+
+def remove_venv(path):
+    shutil.rmtree(path)
+
+
+def check_output_wrapper(version=Version.parse("3.7.1")):
+    def check_output(cmd, *args, **kwargs):
+        if "sys.version_info[:3]" in cmd:
+            return version.text
+        elif "sys.version_info[:2]" in cmd:
+            return "{}.{}".format(version.major, version.minor)
+        else:
+            return str(Path("/prefix"))
+
+    return check_output
+
+
+def test_activate_activates_non_existing_virtualenv_no_envs_file(
+    app, tmp_dir, config, mocker, environ
+):
+    app.poetry._config = config
+
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=check_output_wrapper())
+    mocker.patch(
+        "subprocess.Popen.communicate",
+        side_effect=[("/prefix", None), ("/prefix", None)],
+    )
+    m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
+
+    command = app.find("env use")
+    tester = CommandTester(command)
+    tester.execute("3.7")
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+
+    m.assert_called_with(
+        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)), executable="python3.7"
+    )
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs[venv_name]["minor"] == "3.7"
+    assert envs[venv_name]["patch"] == "3.7.1"
+
+    expected = """\
+Creating virtualenv {} in {}
+Using virtualenv: {}
+""".format(
+        "{}-py3.7".format(venv_name),
+        tmp_dir,
+        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)),
+    )
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
+    app, tmp_dir, config, mocker, environ
+):
+    app.poetry._config = config
+
+    environ["VIRTUAL_ENV"] = "/environment/prefix"
+
+    venv_name = EnvManager.generate_env_name(
+        "simple_project", str(app.poetry.file.parent)
+    )
+    current_python = sys.version_info[:3]
+    python_minor = ".".join(str(v) for v in current_python[:2])
+    python_patch = ".".join(str(v) for v in current_python)
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+    (Path(tmp_dir) / "{}-py{}".format(venv_name, python_minor)).mkdir()
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc[venv_name] = {"minor": python_minor, "patch": python_patch}
+    envs_file.write(doc)
+
+    mocker.patch("subprocess.check_output", side_effect=check_output_wrapper())
+    mocker.patch(
+        "subprocess.Popen.communicate",
+        side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
+    )
+
+    command = app.find("env use")
+    tester = CommandTester(command)
+    tester.execute(python_minor)
+
+    expected = """\
+Using virtualenv: {}
+""".format(
+        os.path.join(tmp_dir, "{}-py{}".format(venv_name, python_minor))
+    )
+
+    assert expected == tester.io.fetch_output()

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -37,7 +37,7 @@ classifiers = [
 
 # Requirements
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.6"
+python = "~2.7 || ^3.4"
 foo = "^1.0"
 """
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1,3 +1,4 @@
+import sys
 from cleo.testers import CommandTester
 
 from poetry.utils._compat import Path
@@ -126,9 +127,11 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^{python}"
 
 [tool.poetry.dev-dependencies]
-"""
+""".format(
+        python=".".join(str(c) for c in sys.version_info[:2])
+    )
 
     assert expected in tester.io.fetch_output()

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,11 +1,12 @@
 from cleo.testers import CommandTester
 
+from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 
 
 def test_run_passes_all_args(app, mocker):
-    env = MockEnv(is_venv=True)
-    mocker.patch("poetry.utils.env.Env.get", return_value=env)
+    env = MockEnv(path=Path("/prefix"), base=Path("/base/prefix"), is_venv=True)
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=env)
 
     command = app.find("run")
     tester = CommandTester(command)

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -17,7 +17,6 @@ from poetry.packages import Locker as BaseLocker
 from poetry.repositories import Pool
 from poetry.repositories import Repository as BaseRepository
 from poetry.utils._compat import Path
-from poetry.utils.env import MockEnv
 from poetry.utils.toml_file import TomlFile
 from poetry.repositories.exceptions import PackageNotFound
 
@@ -50,13 +49,6 @@ def installed():
 
 @pytest.fixture(autouse=True)
 def setup(mocker, installer, installed, config):
-    mocker.patch(
-        "poetry.utils.env.EnvManager.get",
-        return_value=MockEnv(
-            path=Path("/prefix"), base=Path("/base/prefix"), is_venv=True
-        ),
-    )
-
     # Set Installer's installer
     p = mocker.patch("poetry.installation.installer.Installer._get_installer")
     p.return_value = installer

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -49,9 +49,12 @@ def installed():
 
 
 @pytest.fixture(autouse=True)
-def setup(mocker, installer, installed):
+def setup(mocker, installer, installed, config):
     mocker.patch(
-        "poetry.utils.env.Env.get", return_value=MockEnv(is_venv=True, execute=True)
+        "poetry.utils.env.EnvManager.get",
+        return_value=MockEnv(
+            path=Path("/prefix"), base=Path("/base/prefix"), is_venv=True
+        ),
     )
 
     # Set Installer's installer

--- a/tests/fixtures/project_with_git_dev_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_git_dev_dependency/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 # Requirements
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.6"
+python = "~2.7 || ^3.4"
 cachy = "^0.1.0"
 pendulum = "^2.0.0"
 

--- a/tests/fixtures/project_with_local_dependencies/pyproject.toml
+++ b/tests/fixtures/project_with_local_dependencies/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 # Requirements
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.6"
+python = "~2.7 || ^3.4"
 # File dependency
 demo = { path = "../distributions/demo-0.1.0-py2.py3-none-any.whl" }
 

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -22,4 +22,4 @@ classifiers = [
 
 # Requirements
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.6"
+python = "~2.7 || ^3.4"

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -81,7 +81,7 @@ def test_search_for_vcs_setup_egg_info_with_extras(provider):
 
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_vcs_read_setup(provider, mocker):
-    mocker.patch("poetry.utils.env.Env.get", return_value=MockEnv())
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = VCSDependency("demo", "git", "https://github.com/demo/demo.git")
 
@@ -98,7 +98,7 @@ def test_search_for_vcs_read_setup(provider, mocker):
 
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_vcs_read_setup_with_extras(provider, mocker):
-    mocker.patch("poetry.utils.env.Env.get", return_value=MockEnv())
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = VCSDependency("demo", "git", "https://github.com/demo/demo.git")
     dependency.extras.append("foo")
@@ -118,7 +118,7 @@ def test_search_for_vcs_read_setup_with_extras(provider, mocker):
 
 
 def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker):
-    mocker.patch("poetry.utils.env.Env.get", return_value=MockEnv())
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = VCSDependency("demo", "git", "https://github.com/demo/no-version.git")
 
@@ -176,7 +176,7 @@ def test_search_for_directory_setup_egg_info_with_extras(provider):
 
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup(provider, mocker):
-    mocker.patch("poetry.utils.env.Env.get", return_value=MockEnv())
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = DirectoryDependency(
         "demo",
@@ -201,7 +201,7 @@ def test_search_for_directory_setup_read_setup(provider, mocker):
 
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup_with_extras(provider, mocker):
-    mocker.patch("poetry.utils.env.Env.get", return_value=MockEnv())
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = DirectoryDependency(
         "demo",

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,26 +1,295 @@
 import os
-
+import shutil
+import sys
+import tomlkit
+from poetry.io import NullIO
+from poetry.semver import Version
 from poetry.utils._compat import Path
-from poetry.utils.env import Env
+from poetry.utils.env import EnvManager
 from poetry.utils.env import VirtualEnv
+from poetry.utils.toml_file import TomlFile
 
 
-def test_virtualenvs_with_spaces_in_their_path_work_as_expected(tmp_dir):
+def test_virtualenvs_with_spaces_in_their_path_work_as_expected(tmp_dir, config):
     venv_path = Path(tmp_dir) / "Virtual Env"
 
-    Env.build_venv(str(venv_path))
+    EnvManager(config).build_venv(str(venv_path))
 
     venv = VirtualEnv(venv_path)
 
     assert venv.run("python", "-V", shell=True).startswith("Python")
 
 
-def test_env_get_in_project_venv(tmp_dir, environ):
+def test_env_get_in_project_venv(tmp_dir, environ, config):
     if "VIRTUAL_ENV" in environ:
         del environ["VIRTUAL_ENV"]
 
     (Path(tmp_dir) / ".venv").mkdir()
 
-    venv = Env.get(cwd=Path(tmp_dir))
+    venv = EnvManager(config).get(Path(tmp_dir))
 
     assert venv.path == Path(tmp_dir) / ".venv"
+
+
+CWD = Path(__file__).parent.parent / "fixtures" / "simple_project"
+
+
+def build_venv(path, executable=None):
+    os.mkdir(path)
+
+
+def remove_venv(path):
+    shutil.rmtree(path)
+
+
+def test_activate_activates_non_existing_virtualenv_no_envs_file(
+    tmp_dir, config, mocker, environ
+):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["3.7.1", "3.7"])
+    mocker.patch(
+        "subprocess.Popen.communicate",
+        side_effect=[("/prefix", None), ("/prefix", None)],
+    )
+    m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
+
+    env = EnvManager(config).activate("python3.7", CWD, NullIO())
+
+    m.assert_called_with(
+        os.path.join(tmp_dir, "simple_project-py3.7"), executable="python3.7"
+    )
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs["simple_project"]["minor"] == "3.7"
+    assert envs["simple_project"]["patch"] == "3.7.1"
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.7"
+    assert env.base == Path("/prefix")
+
+
+def test_activate_activates_existing_virtualenv_no_envs_file(
+    tmp_dir, config, mocker, environ
+):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    os.mkdir(os.path.join(tmp_dir, "simple_project-py3.7"))
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["3.7.1"])
+    mocker.patch("subprocess.Popen.communicate", side_effect=[("/prefix", None)])
+    m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
+
+    env = EnvManager(config).activate("python3.7", CWD, NullIO())
+
+    m.assert_not_called()
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs["simple_project"]["minor"] == "3.7"
+    assert envs["simple_project"]["patch"] == "3.7.1"
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.7"
+    assert env.base == Path("/prefix")
+
+
+def test_activate_activates_same_virtualenv_with_envs_file(
+    tmp_dir, config, mocker, environ
+):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc["simple_project"] = {"minor": "3.7", "patch": "3.7.1"}
+    envs_file.write(doc)
+
+    os.mkdir(os.path.join(tmp_dir, "simple_project-py3.7"))
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["3.7.1"])
+    mocker.patch("subprocess.Popen.communicate", side_effect=[("/prefix", None)])
+    m = mocker.patch("poetry.utils.env.EnvManager.create_venv")
+
+    env = EnvManager(config).activate("python3.7", CWD, NullIO())
+
+    m.assert_not_called()
+
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs["simple_project"]["minor"] == "3.7"
+    assert envs["simple_project"]["patch"] == "3.7.1"
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.7"
+    assert env.base == Path("/prefix")
+
+
+def test_activate_activates_different_virtualenv_with_envs_file(
+    tmp_dir, config, mocker, environ
+):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc["simple_project"] = {"minor": "3.7", "patch": "3.7.1"}
+    envs_file.write(doc)
+
+    os.mkdir(os.path.join(tmp_dir, "simple_project-py3.7"))
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["3.6.6", "3.6", "3.6"])
+    mocker.patch(
+        "subprocess.Popen.communicate",
+        side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
+    )
+    m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
+
+    env = EnvManager(config).activate("python3.6", CWD, NullIO())
+
+    m.assert_called_with(
+        os.path.join(tmp_dir, "simple_project-py3.6"), executable="python3.6"
+    )
+
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs["simple_project"]["minor"] == "3.6"
+    assert envs["simple_project"]["patch"] == "3.6.6"
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.6"
+    assert env.base == Path("/prefix")
+
+
+def test_activate_activates_recreates_for_different_minor(
+    tmp_dir, config, mocker, environ
+):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc["simple_project"] = {"minor": "3.7", "patch": "3.7.0"}
+    envs_file.write(doc)
+
+    os.mkdir(os.path.join(tmp_dir, "simple_project-py3.7"))
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["3.7.1", "3.7", "3.7"])
+    mocker.patch(
+        "subprocess.Popen.communicate",
+        side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
+    )
+    build_venv_m = mocker.patch(
+        "poetry.utils.env.EnvManager.build_venv", side_effect=build_venv
+    )
+    remove_venv_m = mocker.patch(
+        "poetry.utils.env.EnvManager.remove_venv", side_effect=remove_venv
+    )
+
+    env = EnvManager(config).activate("python3.7", CWD, NullIO())
+
+    build_venv_m.assert_called_with(
+        os.path.join(tmp_dir, "simple_project-py3.7"), executable="python3.7"
+    )
+    remove_venv_m.assert_called_with(os.path.join(tmp_dir, "simple_project-py3.7"))
+
+    assert envs_file.exists()
+    envs = envs_file.read()
+    assert envs["simple_project"]["minor"] == "3.7"
+    assert envs["simple_project"]["patch"] == "3.7.1"
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.7"
+    assert env.base == Path("/prefix")
+    assert (Path(tmp_dir) / "simple_project-py3.7").exists()
+
+
+def test_deactivate_non_activated_but_existing(tmp_dir, config, mocker, environ):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    (
+        Path(tmp_dir)
+        / "simple_project-py{}".format(".".join(str(c) for c in sys.version_info[:2]))
+    ).mkdir()
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["/prefix", "/prefix"])
+
+    EnvManager(config).deactivate(CWD, NullIO())
+    env = EnvManager(config).get(CWD)
+
+    assert env.path == Path(tmp_dir) / "simple_project-py{}".format(
+        ".".join(str(c) for c in sys.version_info[:2])
+    )
+    assert Path("/prefix")
+
+
+def test_deactivate_activated(tmp_dir, config, mocker, environ):
+    if "VIRTUAL_ENV" in environ:
+        del environ["VIRTUAL_ENV"]
+
+    version = Version.parse(".".join(str(c) for c in sys.version_info[:3]))
+    other_version = Version.parse("3.4") if version.major == 2 else version.next_minor
+    (
+        Path(tmp_dir) / "simple_project-py{}.{}".format(version.major, version.minor)
+    ).mkdir()
+    (
+        Path(tmp_dir)
+        / "simple_project-py{}.{}".format(other_version.major, other_version.minor)
+    ).mkdir()
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc["simple_project"] = {
+        "minor": "{}.{}".format(other_version.major, other_version.minor),
+        "patch": other_version.text,
+    }
+    envs_file.write(doc)
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    mocker.patch("subprocess.check_output", side_effect=["/prefix", "/prefix"])
+
+    EnvManager(config).deactivate(CWD, NullIO())
+    env = EnvManager(config).get(CWD)
+
+    assert env.path == Path(tmp_dir) / "simple_project-py{}.{}".format(
+        version.major, version.minor
+    )
+    assert Path("/prefix")
+
+    envs = envs_file.read()
+    assert len(envs) == 0
+
+
+def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
+    tmp_dir, config, mocker, environ
+):
+    environ["VIRTUAL_ENV"] = "/environment/prefix"
+
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+    (Path(tmp_dir) / "simple_project-py3.7").mkdir()
+
+    envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
+    doc = tomlkit.document()
+    doc["simple_project"] = {"minor": "3.7", "patch": "3.7.0"}
+    envs_file.write(doc)
+
+    mocker.patch("subprocess.Popen.communicate", side_effect=[("/prefix", None)])
+
+    env = EnvManager(config).get(CWD)
+
+    assert env.path == Path(tmp_dir) / "simple_project-py3.7"
+    assert env.base == Path("/prefix")

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -317,3 +317,17 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
 
     assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
     assert env.base == Path("/prefix")
+
+
+def test_list(tmp_dir, config):
+    config.add_property("settings.virtualenvs.path", str(tmp_dir))
+
+    venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
+    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+
+    venvs = EnvManager(config).list(CWD)
+
+    assert 2 == len(venvs)
+    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)) == venvs[0].path
+    assert (Path(tmp_dir) / "{}-py3.7".format(venv_name)) == venvs[1].path

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -20,9 +20,9 @@ def test_virtualenvs_with_spaces_in_their_path_work_as_expected(tmp_dir, config)
     assert venv.run("python", "-V", shell=True).startswith("Python")
 
 
-def test_env_get_in_project_venv(tmp_dir, environ, config):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_env_get_in_project_venv(tmp_dir, config):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     (Path(tmp_dir) / ".venv").mkdir()
 
@@ -55,10 +55,10 @@ def check_output_wrapper(version=Version.parse("3.7.1")):
 
 
 def test_activate_activates_non_existing_virtualenv_no_envs_file(
-    tmp_dir, config, mocker, environ
+    tmp_dir, config, mocker
 ):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     config.add_property("settings.virtualenvs.path", str(tmp_dir))
 
@@ -86,11 +86,9 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     assert env.base == Path("/prefix")
 
 
-def test_activate_activates_existing_virtualenv_no_envs_file(
-    tmp_dir, config, mocker, environ
-):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_activate_activates_existing_virtualenv_no_envs_file(tmp_dir, config, mocker):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
 
@@ -116,11 +114,9 @@ def test_activate_activates_existing_virtualenv_no_envs_file(
     assert env.base == Path("/prefix")
 
 
-def test_activate_activates_same_virtualenv_with_envs_file(
-    tmp_dir, config, mocker, environ
-):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_activate_activates_same_virtualenv_with_envs_file(tmp_dir, config, mocker):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
 
@@ -151,10 +147,10 @@ def test_activate_activates_same_virtualenv_with_envs_file(
 
 
 def test_activate_activates_different_virtualenv_with_envs_file(
-    tmp_dir, config, mocker, environ
+    tmp_dir, config, mocker
 ):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
     envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
@@ -191,11 +187,9 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     assert env.base == Path("/prefix")
 
 
-def test_activate_activates_recreates_for_different_minor(
-    tmp_dir, config, mocker, environ
-):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_activate_activates_recreates_for_different_minor(tmp_dir, config, mocker):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
     envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
@@ -238,9 +232,9 @@ def test_activate_activates_recreates_for_different_minor(
     assert (Path(tmp_dir) / "{}-py3.7".format(venv_name)).exists()
 
 
-def test_deactivate_non_activated_but_existing(tmp_dir, config, mocker, environ):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_deactivate_non_activated_but_existing(tmp_dir, config, mocker):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
 
@@ -262,9 +256,9 @@ def test_deactivate_non_activated_but_existing(tmp_dir, config, mocker, environ)
     assert Path("/prefix")
 
 
-def test_deactivate_activated(tmp_dir, config, mocker, environ):
-    if "VIRTUAL_ENV" in environ:
-        del environ["VIRTUAL_ENV"]
+def test_deactivate_activated(tmp_dir, config, mocker):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
     version = Version.parse(".".join(str(c) for c in sys.version_info[:3]))
@@ -302,9 +296,9 @@ def test_deactivate_activated(tmp_dir, config, mocker, environ):
 
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
-    tmp_dir, config, mocker, environ
+    tmp_dir, config, mocker
 ):
-    environ["VIRTUAL_ENV"] = "/environment/prefix"
+    os.environ["VIRTUAL_ENV"] = "/environment/prefix"
 
     venv_name = EnvManager.generate_env_name("simple_project", str(CWD))
 


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This PR introduces a new `env` command with related sub commands, to make it easier to explicitly associate a Python version with the current project. This addresses #621.

Here are the changes:

### New `env use` command

The `env use` command tells Poetry which Python version
to use for the current project.

```bash
poetry env use /full/path/to/python
```

If the python executable is in the `PATH`, it's possible to use it:

```bash
poetry env use python3.7
```

It's also possible in this case to only specify the minor Python version:

```bash
poetry env use 3.7
```

To disable the explicitly activated virtualenv, it's possible to use the
special `system` Python version to retrieve the default behavior:

```bash
poetry env use system
```

### New `env info` command

The `env info` command displays basic information about the currently activated virtualenv:

```bash
poetry env info
```

will output something similar to this:

```text
Virtualenv
Python:         3.7.1
Implementation: CPython
Path:           /path/to/poetry/cache/virtualenvs/test-O3eWbxRl-py3.7
Valid:          True

System
Platform: darwin
OS:       posix
Python:   /path/to/main/python
```

It's possible to only display the path of the virtualenv by passing the `--path` option
to `env info`:

```bash
poetry env info --path
```

### New `env list` command

The `env list` command lists all the virtualenvs associated with the current virtualenv.

```bash
poetry env list
```

will output something like the following:

```text
test-O3eWbxRl-py2.7
test-O3eWbxRl-py3.6
test-O3eWbxRl-py3.7 (Activated)
```

### New `env remove` command

The `env remove` command deletes virtualenvs associated with the current project:

```bash
poetry env remove /full/path/to/python
```

Similarly to `env use`, it's possible to pass either `python3.7`, `3.7` or the name of
the virtualenv (as returned by `env list`):

```bash
poetry env remove python3.7
poetry env remove 3.7
poetry env remove test-O3eWbxRl-py3.7
```

### Virtualenvs names now depend on the path of the project

This makes having different projects with the same name possible.