### PR TITLE
Fix request authentication when credentials are included in URLs

### DIFF
--- a/poetry/repositories/auth.py
+++ b/poetry/repositories/auth.py
@@ -7,11 +7,11 @@ from poetry.utils._compat import urlparse
 
 class Auth(AuthBase):
     def __init__(self, url, username, password):  # type: (str, str, str) -> None
-        self._netloc = urlparse.urlparse(url).netloc
+        self._hostname = urlparse.urlparse(url).hostname
         self._auth = HTTPBasicAuth(username, password)
 
     def __call__(self, r):  # type: (Request) -> Request
-        if urlparse.urlparse(r.url).netloc != self._netloc:
+        if urlparse.urlparse(r.url).hostname != self._hostname:
             return r
 
         self._auth(r)

--- a/tests/repositories/test_auth.py
+++ b/tests/repositories/test_auth.py
@@ -21,6 +21,20 @@ def test_auth_with_request_on_the_same_host():
     )
 
 
+def test_auth_with_request_with_same_authentication():
+    auth = Auth("https://poetry.eustace.io", "foo", "bar")
+
+    request = Request("GET", "https://foo:bar@poetry.eustace.io/docs/")
+    assert "Authorization" not in request.headers
+
+    request = auth(request)
+
+    assert "Authorization" in request.headers
+    assert request.headers["Authorization"] == "Basic {}".format(
+        decode(base64.b64encode(encode(":".join(("foo", "bar")))))
+    )
+
+
 def test_auth_with_request_on_different_hosts():
     auth = Auth("https://poetry.eustace.io", "foo", "bar")
 


### PR DESCRIPTION
Some package repositories which require basic HTTP authentication include the user's credentials in URLs returned as part of JSON responses. Because Poetry's request authentication system checks for a matching `netloc`, this ends up breaking basic HTTP authentication for such repositories. This pull request compares by `hostname` instead of `netloc`. Because `hostname` doesn't include any extra URL authentication information, this fixes access to these repositories.

This fixes issue #746.

## Pull Request Check List
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles! -->
- [ x ] Added **tests** for changed code.
- [ x ] Updated **documentation** for changed code.
