### PR TITLE
[Documentation] Recommend Python3 to install Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python3
 ```
 
 Alternatively, you can download the `get-poetry.py` file and execute it separately.


### PR DESCRIPTION
Since Poetry requires Python 3 to run, it should also use the `python3` interpreter for installation. `python` normally refers to python 2 and therefore creates a poetry binary with !# /usr/bin/env python shebang. Poetry then fails with RuntimeError, as the binary tries to use python 2.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Updated **documentation** for changed code.
