### PR TITLE
Fix PATH being altered after installation even though choose not to

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -600,7 +600,6 @@ class Installer:
 
         addition = "\n{}\n".format(export_string)
 
-        updated = []
         profiles = self.get_unix_profiles()
         for profile in profiles:
             if not os.path.exists(profile):
@@ -612,8 +611,6 @@ class Installer:
             if addition not in content:
                 with open(profile, "a") as f:
                     f.write(addition)
-
-                updated.append(os.path.relpath(profile, HOME))
 
     def add_to_windows_path(self):
         try:

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -589,6 +589,9 @@ class Installer:
         """
         Tries to update the $PATH automatically.
         """
+        if not self._modify_path:
+            return
+
         if WINDOWS:
             return self.add_to_windows_path()
 


### PR DESCRIPTION
I tried poetry today and noticed that `_modify_path` is only used to change messages so when I chose no altering PATH, it still edited my .profile and .zshenv

Is it safe to delete [`updated`](https://github.com/sdispater/poetry/blob/master/get-poetry.py#L600) list in update_path? I see items (path) being added to it but it is not used anywhere.
