### PR TITLE
Adds support for adding package from remote urls

### DIFF
--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -10,6 +10,7 @@ class AddCommand(EnvCommand, InitCommand):
         { name* : Packages to add. }
         { --D|dev : Add package as development dependency. }
         { --git= : The url of the Git repository. }
+        { --url= : The url of the package. }
         { --path= : The path to a dependency. }
         { --E|extras=* : Extras to activate for the dependency. }
         { --optional : Add as an optional dependency. }
@@ -35,9 +36,12 @@ If you do not specify a version constraint, poetry will choose a suitable one ba
         packages = self.argument("name")
         is_dev = self.option("dev")
 
-        if (self.option("git") or self.option("path") or self.option("extras")) and len(
-            packages
-        ) > 1:
+        if (
+            self.option("url")
+            or self.option("git")
+            or self.option("path")
+            or self.option("extras")
+        ) and len(packages) > 1:
             raise ValueError(
                 "You can only specify one package "
                 "when using the --git or --path options"
@@ -62,7 +66,7 @@ If you do not specify a version constraint, poetry will choose a suitable one ba
                 if key.lower() == name.lower():
                     raise ValueError("Package {} is already present".format(name))
 
-        if self.option("git") or self.option("path"):
+        if self.option("git") or self.option("path") or self.option("url"):
             requirements = {packages[0]: ""}
         else:
             requirements = self._determine_requirements(
@@ -86,6 +90,10 @@ If you do not specify a version constraint, poetry will choose a suitable one ba
                 del constraint["version"]
 
                 constraint["path"] = self.option("path")
+            elif self.option("url"):
+                del constraint["version"]
+
+                constraint["url"] = self.option("url")
 
             if self.option("optional"):
                 constraint["optional"] = True

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -132,6 +132,9 @@ class PipInstaller(BaseInstaller):
 
             return req
 
+        if package.source_type == "url":
+            return package.source_url
+
         if package.source_type == "git":
             return "git+{}@{}#egg={}".format(
                 package.source_url, package.source_reference, package.name

--- a/poetry/packages/__init__.py
+++ b/poetry/packages/__init__.py
@@ -7,6 +7,7 @@ from .dependency import Dependency
 from .dependency_package import DependencyPackage
 from .directory_dependency import DirectoryDependency
 from .file_dependency import FileDependency
+from .url_dependency import UrlDependency
 from .locker import Locker
 from .package import Package
 from .package_collection import PackageCollection

--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -139,6 +139,9 @@ class Dependency(object):
     def is_vcs(self):
         return False
 
+    def is_url(self):
+        return False
+
     def is_file(self):
         return False
 

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -5,6 +5,7 @@ import re
 from contextlib import contextmanager
 from typing import Union
 
+from poetry.packages.url_dependency import UrlDependency
 from poetry.semver import Version
 from poetry.semver import parse_constraint
 from poetry.spdx import license_by_id
@@ -262,6 +263,12 @@ class Package(object):
 
                 dependency = FileDependency(
                     name, file_path, category=category, base=self.root_dir
+                )
+            elif "url" in constraint:
+                url = constraint["url"]
+
+                dependency = UrlDependency(
+                    name, url, category=category, optional=optional
                 )
             elif "path" in constraint:
                 path = Path(constraint["path"])

--- a/poetry/packages/url_dependency.py
+++ b/poetry/packages/url_dependency.py
@@ -1,0 +1,25 @@
+from poetry.utils._compat import Path
+
+from .dependency import Dependency
+
+
+class UrlDependency(Dependency):
+    def __init__(
+        self,
+        name,
+        url,  # type: Path
+        category="main",  # type: str
+        optional=False,  # type: bool
+    ):
+        self._url = url
+
+        super(UrlDependency, self).__init__(
+            name, "*", category=category, optional=optional, allows_prereleases=True
+        )
+
+    @property
+    def url(self):
+        return self._url
+
+    def is_url(self):
+        return True

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -207,7 +207,7 @@ class Provider:
         return [package]
 
     def search_for_url(self, dependency):  # type: (UrlDependency) -> List[Package]
-        tmp_dir = Path(mkdtemp(prefix="pypoetry-git-{}".format(dependency.name)))
+        tmp_dir = Path(mkdtemp(prefix="pypoetry-url-{}".format(dependency.name)))
 
         # TODO: The file name might be in the request header itself
         file_name = urlparse(dependency.url).path.split("/")[-1]

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -218,13 +218,21 @@ class Provider:
         with tmp_file.open("wb") as f:
             shutil.copyfileobj(response.raw, f)
 
-        file_dep = FileDependency(
+        file_dependency = FileDependency(
             dependency.name,
             tmp_file,
             category=dependency.category,
             optional=dependency.is_optional(),
         )
-        return self.search_for_file(file_dep)
+        for extra in dependency.extras:
+            file_dependency.extras.append(extra)
+
+        package = self.search_for_file(file_dependency)[0]
+
+        package.source_type = "url"
+        package.source_url = dependency.url
+
+        return [package]
 
     def search_for_file(self, dependency):  # type: (FileDependency) -> List[Package]
         if dependency.path.suffix == ".whl":
@@ -485,6 +493,7 @@ class Provider:
             "directory",
             "file",
             "git",
+            "url",
         }:
             package = DependencyPackage(
                 package.dependency,


### PR DESCRIPTION
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR adds support for installing packages from remote URLs, by passing a `--url` parameter. e.g.:

`poetry add minibar --url https://github.com/canassa/minibar/archive/master.zip`

I really needed this feature in order to keep using poetry in my internal company projects, therefore I hacked this PR together yesterday. This is really a proof-of-concept and not something production grade, I am opening this PR because I would like to get some feedback about this before I invest more time in it. Some question that I have are:

- Is this a welcomed feature?
- Do you agree with the new `--url` parameter, or do you prefer something else?
- Did I took the correct approach by subclassing `Dependency` and implementing the `search_for_url` that download the file and calls the `search_for_file` method?

Fixes #695 

Thanks!
