### PR TITLE
Compress all wheel content with explicit ZIP_DEFLATED (#715)

### DIFF
--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -259,7 +259,7 @@ class WheelBuilder(Builder):
                 hashsum.update(buf)
 
             src.seek(0)
-            wheel.writestr(zinfo, src.read())
+            wheel.writestr(zinfo, src.read(), compress_type=zipfile.ZIP_DEFLATED)
 
         size = os.stat(full_path).st_size
         hash_digest = urlsafe_b64encode(hashsum.digest()).decode("ascii").rstrip("=")


### PR DESCRIPTION
https://docs.python.org/2/library/zipfile.html#zipfile.ZipFile.writestr

Note: When passing a ZipInfo instance as the zinfo_or_arcname parameter,
the compression method used will be that specified in the compress_type
member of the given ZipInfo instance. By default, the ZipInfo
constructor sets this member to ZIP_STORED.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
