### PR TITLE
Prevent indefinite hanging during installation of Poetry itself

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -814,9 +814,14 @@ class Installer:
         return subprocess.check_output(args, stderr=subprocess.STDOUT)
 
     def _get(self, url):
+        """Perform a GET request through Python to a specific URL
+
+        The URL connection has a specific timeout set to 2 seconds
+        to prevent indefinite hanging in certain edge cases
+        """
         request = Request(url, headers={"User-Agent": "Python Poetry"})
 
-        with closing(urlopen(request)) as r:
+        with closing(urlopen(request, timeout=2)) as r:
             return r.read()
 
 


### PR DESCRIPTION
## My system

* Linux Mint 19.1
* Shell: zsh
* Python Version: 3.7.1 (managed through pyenv)

## Issue: Bug

When attempting to install Poetry itself, the installation hangs indefinitely. Example:

```bash
curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
# Hangs forever...
```

## Resolution: Bug Fix

By adding an explicit timeout to the _get() method within get-poetry.py, the strange connection bug disappeared.

## Considerations

It's possible that, for some supremely slow connections, the 2 second limit I selected may be too short. Worth thinking about if and when you think about merging this.

# Pull Request Check List

- [N/A, it's a non-importable script ] Added **tests** for changed code.
- [X ] Updated **documentation** for changed code.