### PR TITLE
Commonize pip running logic and use system pip in system env

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -115,7 +115,7 @@ class PipInstaller(BaseInstaller):
             raise
 
     def run(self, *args, **kwargs):  # type: (...) -> str
-        return self._env.run("python", "-m", "pip", *args, **kwargs)
+        return self._env.run_pip(*args, **kwargs)
 
     def requirement(self, package, formatted=False):
         if formatted and not package.source_type:

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -31,16 +31,14 @@ class EditableBuilder(Builder):
 
         try:
             if self._env.pip_version < Version(19, 0):
-                self._env.run("python", "-m", "pip", "install", "-e", str(self._path))
+                self._env.run_pip("install", "-e", str(self._path))
             else:
                 # Temporarily rename pyproject.toml
                 shutil.move(
                     str(self._poetry.file), str(self._poetry.file.with_suffix(".tmp"))
                 )
                 try:
-                    self._env.run(
-                        "python", "-m", "pip", "install", "-e", str(self._path)
-                    )
+                    self._env.run_pip("install", "-e", str(self._path))
                 finally:
                     shutil.move(
                         str(self._poetry.file.with_suffix(".tmp")),

--- a/tests/masonry/builders/test_editable.py
+++ b/tests/masonry/builders/test_editable.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import sys
+
 from clikit.io import NullIO
 
 from poetry.factory import Factory
@@ -22,7 +24,7 @@ def test_build_should_delegate_to_pip_for_non_pure_python_packages(tmp_dir, mock
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())
     builder.build()
 
-    expected = [["python", "-m", "pip", "install", "-e", str(module_path)]]
+    expected = [[sys.executable, "-m", "pip", "install", "-e", str(module_path)]]
     assert expected == env.executed
 
     assert 0 == move.call_count
@@ -38,7 +40,7 @@ def test_build_should_temporarily_remove_the_pyproject_file(tmp_dir, mocker):
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())
     builder.build()
 
-    expected = [["python", "-m", "pip", "install", "-e", str(module_path)]]
+    expected = [[sys.executable, "-m", "pip", "install", "-e", str(module_path)]]
     assert expected == env.executed
 
     assert 2 == move.call_count


### PR DESCRIPTION
- [X] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This is a more complete fix for #712 and #716 - there's now a common function to run the appropriate pip for an environment with given arguments, and all (AFAICT) locations where pip is invoked inside Poetry are changed to use it. It's technically a behavior change for cases where Poetry is running outside a virtual environment _and_ with a non-default Python, but I'm not sure if those are common enough to consider this a serious breaking change. The behavior inside virtualenvs is unaffected.

For a bit more context, this allows using Poetry to install stuff in a system environment for non-system Pythons, e.g. `pip3 install poetry && poetry install` will do the right thing in a CentOS container where `pip` is always a symlink to `pip2`.

This PR is identical to #831, except now on its own branch