### PR TITLE
Fix returning error code 0 on HTTP errors in poetry publish

### DIFF
--- a/poetry/console/commands/publish.py
+++ b/poetry/console/commands/publish.py
@@ -1,3 +1,5 @@
+from requests import HTTPError
+
 from .command import Command
 
 
@@ -50,6 +52,12 @@ the config command.
 
         self.line("")
 
-        publisher.publish(
-            self.option("repository"), self.option("username"), self.option("password")
-        )
+        try:
+            publisher.publish(
+                self.option("repository"),
+                self.option("username"),
+                self.option("password"),
+            )
+        except HTTPError as e:
+            self.line_error("<error>Server responded with error: {}</error>".format(e))
+            return 1


### PR DESCRIPTION
Cleo checks `errno`, which is set on Requests errors (since they're a subclass of `IOError`). So, catch the error here instead and fail directly with exit code 1. This fixes running `poetry publish` in a CI environment. Another solution might be to handle the `e.errno is None` case explicitly in Cleo.