### PR TITLE
[724] handle ast.Name values in extras_require

### DIFF
--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -282,7 +282,11 @@ class SetupReader(object):
 
         if isinstance(value, ast.Dict):
             for key, val in zip(value.keys, value.values):
-                extras_require[key.s] = [e.s for e in val.elts]
+                if isinstance(val, ast.Name):
+                    val = self._find_variable_in_body(body, val.id)
+
+                if isinstance(val, ast.List):
+                    extras_require[key.s] = [e.s for e in val.elts]
         elif isinstance(value, ast.Name):
             variable = self._find_variable_in_body(body, value.id)
 
@@ -290,7 +294,11 @@ class SetupReader(object):
                 return extras_require
 
             for key, val in zip(variable.keys, variable.values):
-                extras_require[key.s] = [e.s for e in val.elts]
+                if isinstance(val, ast.Name):
+                    val = self._find_variable_in_body(body, val.id)
+
+                if isinstance(val, ast.List):
+                    extras_require[key.s] = [e.s for e in val.elts]
 
         return extras_require
 

--- a/tests/utils/fixtures/setups/extras_require_with_vars/setup.py
+++ b/tests/utils/fixtures/setups/extras_require_with_vars/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+tests_require = ["pytest"]
+
+setup(
+    name="extras_require_with_vars",
+    version="0.0.1",
+    description="test setup_reader.py",
+    install_requires=[],
+    extras_require={"test": tests_require},
+)

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -149,3 +149,20 @@ def test_setup_reader_read_setup_call_in_main(setup):
     assert expected_install_requires == result["install_requires"]
     assert expected_extras_require == result["extras_require"]
     assert expected_python_requires == result["python_requires"]
+
+
+@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
+def test_setup_reader_read_extras_require_with_variables(setup):
+    result = SetupReader.read_from_directory(setup("extras_require_with_vars"))
+
+    expected_name = "extras_require_with_vars"
+    expected_version = "0.0.1"
+    expected_install_requires = []
+    expected_extras_require = {"test": ["pytest"]}
+    expected_python_requires = None
+
+    assert expected_name == result["name"]
+    assert expected_version == result["version"]
+    assert expected_install_requires == result["install_requires"]
+    assert expected_extras_require == result["extras_require"]
+    assert expected_python_requires == result["python_requires"]


### PR DESCRIPTION
Fixes #724.

* [x]  Added **tests** for changed code.

There are more possibilities of confusing the parser, like calls as values for, ie `extras_require={'key': func(). ...}`. IMHO there needs to be a way to give-up and raise an expressive error message.

#725 is a previous version of this which is based on the `develop` branch