### PR TITLE
Support double dash in run command arguments

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -313,6 +313,8 @@ poetry run my-script
 
 Note that this command has no option.
 
+All arguments following a double dash (`--`) are passed on to the given command. 
+
 ## shell
 
 The `shell` command spawns a shell,

--- a/poetry/console/args/run_args_parser.py
+++ b/poetry/console/args/run_args_parser.py
@@ -37,7 +37,7 @@ class RunArgsParser(DefaultArgsParser):
             # Do not include options that preceed the double dash
             double_dash_idx = tokens.index("--")
             for idx, token in enumerate(tokens):
-                if not (idx < double_dash_idx and token.startswith("-")):
+                if not (idx <= double_dash_idx and token.startswith("-")):
                     self._arguments[last_arg.name].append(token)
         else:
             self._arguments[last_arg.name] = tokens[:]

--- a/poetry/console/args/run_args_parser.py
+++ b/poetry/console/args/run_args_parser.py
@@ -30,12 +30,14 @@ class RunArgsParser(DefaultArgsParser):
         tokens = raw_args.tokens[:]
 
         last_arg = list(fmt.get_arguments().values())[-1]
+
         self._arguments[last_arg.name] = []
 
-        while True:
-            try:
-                token = tokens.pop(0)
-            except IndexError:
-                break
-
-            self._arguments[last_arg.name].append(token)
+        if "--" in tokens:
+            # Do not include options that preceed the double dash
+            double_dash_idx = tokens.index("--")
+            for idx, token in enumerate(tokens):
+                if not (idx < double_dash_idx and token.startswith("-")):
+                    self._arguments[last_arg.name].append(token)
+        else:
+            self._arguments[last_arg.name] = tokens[:]

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -14,3 +14,15 @@ def test_run_passes_all_args(app, mocker):
     tester.execute("python -V")
 
     assert [["python", "-V"]] == env.executed
+
+
+def test_double_dash(app, mocker):
+    env = MockEnv(path=Path("/prefix"), base=Path("/base/prefix"), is_venv=True)
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=env)
+
+    command = app.find("run")
+    tester = CommandTester(command)
+
+    tester.execute("python -h -- -v")
+
+    assert [["python", "-v"]] == env.executed


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This PR introduces support for the [double-dash](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) (`--`) argument in `run` argument lists.

`poetry run python3 -- -h` would have previously resulted in `clikit.config.default_application_config.DefaultApplicationConfig.resolve_help_command` being called, which would consequently stop command propagation and print the help text pertaining to the issued command. An event listener with a higher priority (1 instead of 0) than `resolve_help_command` is added to the Poetry application config to prevent this from happening.
Commands that include global options which precede the double dash (e.g. `poetry run python3 -h -- -h`) are left untouched by the listener, and will still have the same outcome as before.

Closes #915