### PR TITLE
Allow local version identifier in wheel filenames #756

### DIFF
--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -214,7 +214,7 @@ class WheelBuilder(Builder):
 
     def dist_info_name(self, distribution, version):  # type: (...) -> str
         escaped_name = re.sub(r"[^\w\d.]+", "_", distribution, flags=re.UNICODE)
-        escaped_version = re.sub(r"[^\w\d.]+", "_", version, flags=re.UNICODE)
+        escaped_version = re.sub(r"[^\w\d.+]+", "_", version, flags=re.UNICODE)
 
         return "{}-{}.dist-info".format(escaped_name, escaped_version)
 

--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -203,7 +203,7 @@ class WheelBuilder(Builder):
     def wheel_filename(self):  # type: () -> str
         return "{}-{}-{}.whl".format(
             re.sub(r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE),
-            re.sub(r"[^\w\d.]+", "_", self._meta.version, flags=re.UNICODE),
+            re.sub(r"[^\w\d.\+]+", "_", self._meta.version, flags=re.UNICODE),
             self.tag,
         )
 

--- a/tests/masonry/builders/fixtures/localversionlabel/README.rst
+++ b/tests/masonry/builders/fixtures/localversionlabel/README.rst
@@ -1,0 +1,2 @@
+Local version label
+===================

--- a/tests/masonry/builders/fixtures/localversionlabel/localversionlabel.py
+++ b/tests/masonry/builders/fixtures/localversionlabel/localversionlabel.py
@@ -1,0 +1,3 @@
+"""Example module"""
+
+__version__ = "0.1"

--- a/tests/masonry/builders/fixtures/localversionlabel/pyproject.toml
+++ b/tests/masonry/builders/fixtures/localversionlabel/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "localversionlabel"
+version = "0.1-beta.1+gitbranch-buildno-1"
+description = "Some description."
+authors = [
+    "Sébastien Eustace <sebastien@eustace.io>"
+]
+license = "MIT"
+
+readme = "README.rst"
+
+homepage = "https://poetry.eustace.io/"

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -64,14 +64,13 @@ def test_wheel_prerelease():
 def test_wheel_localversionlabel():
     module_path = fixtures_dir / "localversionlabel"
     WheelBuilder.make(Poetry.create(str(module_path)), NullEnv(), NullIO())
-
-    whl = (
-        module_path
-        / "dist"
-        / "localversionlabel-0.1b1+gitbranch.buildno.1-py2.py3-none-any.whl"
-    )
+    local_version_string = "localversionlabel-0.1b1+gitbranch.buildno.1"
+    whl = module_path / "dist" / (local_version_string + "-py2.py3-none-any.whl")
 
     assert whl.exists()
+
+    with zipfile.ZipFile(str(whl)) as z:
+        assert local_version_string + ".dist-info/METADATA" in z.namelist()
 
 
 def test_wheel_package_src():

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -61,6 +61,19 @@ def test_wheel_prerelease():
     assert whl.exists()
 
 
+def test_wheel_localversionlabel():
+    module_path = fixtures_dir / "localversionlabel"
+    WheelBuilder.make(Poetry.create(str(module_path)), NullEnv(), NullIO())
+
+    whl = (
+        module_path
+        / "dist"
+        / "localversionlabel-0.1b1+gitbranch.buildno.1-py2.py3-none-any.whl"
+    )
+
+    assert whl.exists()
+
+
 def test_wheel_package_src():
     module_path = fixtures_dir / "source_package"
     WheelBuilder.make(Poetry.create(str(module_path)), NullEnv(), NullIO())


### PR DESCRIPTION
Fixes cases where the version part of the wheel file name would become

`0.1b1_gitbranch.buildno.1`

instead of

`0.1b1+gitbranch.buildno.1`

fixes #756 

- [x] Added **tests** for changed code.
- ~[] Updated **documentation** for changed code.~ N/A
