### PR TITLE
Requirements export fix

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -42,7 +42,7 @@ class ExportCommand(Command):
                 "</warning>"
             )
 
-        exporter = Exporter(self.poetry.locker)
+        exporter = Exporter(self.poetry.locker, self.poetry.pool)
         exporter.export(
             fmt,
             self.poetry.file.parent,

--- a/poetry/repositories/auth.py
+++ b/poetry/repositories/auth.py
@@ -24,7 +24,7 @@ class Auth(AuthBase):
         return r
 
 
-class NetrcAuth(AuthBase):
+class URLAuth(AuthBase):
     def __init__(self, url, username, password):  # type: (str, str, str) -> None
 
         self._url = url
@@ -45,5 +45,5 @@ class NetrcAuth(AuthBase):
         return r
 
     @classmethod
-    def from_auth(cls, auth):  # type: (Auth) -> NetrcAuth
-        return NetrcAuth(auth._url, auth._username, auth._password)
+    def from_auth(cls, auth):  # type: (Auth) -> URLAuth
+        return URLAuth(auth._url, auth._username, auth._password)

--- a/poetry/repositories/auth.py
+++ b/poetry/repositories/auth.py
@@ -2,7 +2,7 @@ from requests import Request
 from requests.auth import AuthBase
 from requests.auth import HTTPBasicAuth
 
-from poetry.utils._compat import urlparse
+from poetry.utils._compat import urlparse, quote
 
 
 def _hostnames_matches(url, base_url):
@@ -37,11 +37,11 @@ class URLAuth(AuthBase):
 
         url_parts = urlparse.urlparse(r.url)
         netrc_url = "{}:{}@{}".format(
-            urlparse.quote(self._username, safe=""),
-            urlparse.quote(self._password, safe=""),
-            url_parts[1],
+            quote(self._username, safe=""), quote(self._password, safe=""), url_parts[1]
         )
-        r.url = urlparse.urlunparse([url_parts[0], netrc_url, *url_parts[2:]])
+        url_parts_with_cred = list(url_parts)
+        url_parts_with_cred[1] = netrc_url
+        r.url = urlparse.urlunparse(url_parts_with_cred)
         return r
 
     @classmethod

--- a/poetry/repositories/auth.py
+++ b/poetry/repositories/auth.py
@@ -5,15 +5,45 @@ from requests.auth import HTTPBasicAuth
 from poetry.utils._compat import urlparse
 
 
+def _hostnames_matches(url, base_url):
+    return urlparse.urlparse(url).hostname == urlparse.urlparse(base_url).hostname
+
+
 class Auth(AuthBase):
     def __init__(self, url, username, password):  # type: (str, str, str) -> None
-        self._hostname = urlparse.urlparse(url).hostname
-        self._auth = HTTPBasicAuth(username, password)
+        self._url = url
+        self._username = username
+        self._password = password
 
     def __call__(self, r):  # type: (Request) -> Request
-        if urlparse.urlparse(r.url).hostname != self._hostname:
+        if not _hostnames_matches(r.url, self._url):
             return r
 
-        self._auth(r)
+        HTTPBasicAuth(self._username, self._password)(r)
 
         return r
+
+
+class NetrcAuth(AuthBase):
+    def __init__(self, url, username, password):  # type: (str, str, str) -> None
+
+        self._url = url
+        self._username = username
+        self._password = password
+
+    def __call__(self, r):  # type: (Request) -> Request
+        if not _hostnames_matches(r.url, self._url):
+            return r
+
+        url_parts = urlparse.urlparse(r.url)
+        netrc_url = "{}:{}@{}".format(
+            urlparse.quote(self._username, safe=""),
+            urlparse.quote(self._password, safe=""),
+            url_parts[1],
+        )
+        r.url = urlparse.urlunparse([url_parts[0], netrc_url, *url_parts[2:]])
+        return r
+
+    @classmethod
+    def from_auth(cls, auth):  # type: (Auth) -> NetrcAuth
+        return NetrcAuth(auth._url, auth._username, auth._password)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -183,12 +183,25 @@ class LegacyRepository(PyPiRepository):
         url_parts = urlparse.urlparse(self._url)
         if not url_parts.username and auth:
             self._session.auth = auth
+            self._auth = auth
+        elif url_parts.username:
+            self._auth = Auth(self._url, url_parts.username, url_parts.password)
+        else:
+            self._auth = None
 
         self._disable_cache = disable_cache
 
     @property
     def name(self):
         return self._name
+
+    @property
+    def auth(self):  # type: () -> Optional[Auth]
+        return self._auth
+
+    @property
+    def url(self):
+        return self._url
 
     def find_packages(
         self, name, constraint=None, extras=None, allow_prereleases=False

--- a/poetry/utils/_compat.py
+++ b/poetry/utils/_compat.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     import urlparse
 
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
+
 try:  # Python 2
     long = long
     unicode = unicode

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -2,7 +2,7 @@ import requests
 
 from poetry.packages.locker import Locker
 from poetry.repositories import Pool
-from poetry.repositories.auth import NetrcAuth
+from poetry.repositories.auth import URLAuth
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.utils._compat import Path
 from poetry.utils._compat import decode
@@ -35,7 +35,7 @@ class Exporter(object):
         for repo in repositories:
             if isinstance(repo, LegacyRepository):
                 if repo.auth:
-                    auth = NetrcAuth.from_auth(repo.auth)
+                    auth = URLAuth.from_auth(repo.auth)
                     r = auth(requests.Request("GET", repo.url))
                     formatted_repos.add(r.url)
                 else:

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -33,12 +33,13 @@ class Exporter(object):
     def _format_repositories(repositories):
         formatted_repos = set()
         for repo in repositories:
-            if isinstance(repo, LegacyRepository) and repo.auth:
-                auth = NetrcAuth.from_auth(repo.auth)
-                r = auth(requests.Request("GET", repo.url))
-                formatted_repos.add(r.url)
-            else:
-                formatted_repos.add(repo.url)
+            if isinstance(repo, LegacyRepository):
+                if repo.auth:
+                    auth = NetrcAuth.from_auth(repo.auth)
+                    r = auth(requests.Request("GET", repo.url))
+                    formatted_repos.add(r.url)
+                else:
+                    formatted_repos.add(repo.url)
         return formatted_repos
 
     def _export_requirements_txt(

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -5,9 +5,11 @@ import pytest
 
 from cleo.testers import CommandTester
 
+from poetry.repositories.auth import Auth
+from poetry.repositories.legacy_repository import LegacyRepository
 from tests.helpers import get_package
 
-from ..conftest import Application
+from ..conftest import Application, Config
 from ..conftest import Path
 from ..conftest import Poetry
 
@@ -43,14 +45,28 @@ foo = "^1.0"
 
 
 @pytest.fixture
-def poetry(repo, tmp_dir):
+def legacy_repo():
+    auth = Auth("https://pypi.myserver.com:443/simple", "johndoe#$%", "passwd123(*(")
+    return LegacyRepository("private", auth._url, auth)
+
+
+@pytest.fixture
+def poetry(repo, legacy_repo, tmp_dir):
     with (Path(tmp_dir) / "pyproject.toml").open("w", encoding="utf-8") as f:
         f.write(PYPROJECT_CONTENT)
 
     p = Poetry.create(Path(tmp_dir))
+    p._auth_config = Config(None)
+    p.auth_config.add_property(
+        "http-basic.private.username", legacy_repo._auth._username
+    )
+    p.auth_config.add_property(
+        "http-basic.private.password", legacy_repo._auth._password
+    )
 
     p.pool.remove_repository("pypi")
     p.pool.add_repository(repo)
+    p.pool.add_repository(legacy_repo)
     p._locker.write()
 
     yield p
@@ -80,6 +96,7 @@ def test_export_exports_requirements_txt_file_locks_if_no_lock_file(app, repo):
     assert app.poetry.locker.lock.exists()
 
     expected = """\
+--extra-index-url https://johndoe%23%24%25:passwd123%28%2A%28@pypi.myserver.com:443/simple
 foo==1.0.0
 """
 
@@ -110,6 +127,7 @@ def test_export_exports_requirements_txt_uses_lock_file(app, repo):
     assert app.poetry.locker.lock.exists()
 
     expected = """\
+--extra-index-url https://johndoe%23%24%25:passwd123%28%2A%28@pypi.myserver.com:443/simple
 foo==1.0.0
 """
 

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -93,6 +93,9 @@ class Config(BaseConfig):
     def __init__(self, _):
         self._content = document()
 
+    def dump(self):
+        pass
+
 
 class Locker(BaseLocker):
     def __init__(self, lock, local_config):
@@ -139,9 +142,12 @@ class Poetry(BasePoetry):
         self._local_config = local_config
         self._locker = Locker(locker.lock.path, locker._local_config)
         self._config = Config.create("config.toml")
+        self._auth_config = Config.create("auth.toml")
 
         # Configure sources
         self._pool = Pool()
+        for source in self._local_config.get("source", []):
+            self._pool.add_repository(self.create_legacy_repository(source))
 
 
 class Repository(BaseRepository):

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -395,11 +395,82 @@ def test_exporter_exports_requirements_txt_with_legacy_packages(tmp_dir, locker)
         content = f.read()
 
     expected = """\
+--extra-index-url https://example.com/simple/
 bar==4.5.6 \\
-    --index-url https://example.com/simple/ \\
     --hash=sha256:67890
 foo==1.2.3 \\
     --hash=sha256:12345
+"""
+
+    assert expected == content
+
+
+def test_exporter_exports_requirements_txt_with_multiple_legacy_packages(
+    tmp_dir, locker
+):
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example2.com/simple/",
+                        "reference": "",
+                    },
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "dev",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example.com/simple/",
+                        "reference": "",
+                    },
+                },
+                {
+                    "name": "gar",
+                    "version": "7.8.9",
+                    "category": "dev",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example.com/simple/",
+                        "reference": "",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": ["12345"], "bar": ["67890"], "gar": ["abcde"]},
+            },
+        }
+    )
+    exporter = Exporter(locker)
+
+    exporter.export("requirements.txt", Path(tmp_dir), dev=True)
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+--extra-index-url https://example.com/simple/
+--extra-index-url https://example2.com/simple/
+bar==4.5.6 \\
+    --hash=sha256:67890
+foo==1.2.3 \\
+    --hash=sha256:12345
+gar==7.8.9 \\
+    --hash=sha256:abcde
 """
 
     assert expected == content

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -1,6 +1,9 @@
 import pytest
 
 from poetry.packages import Locker as BaseLocker
+from poetry.repositories import Pool
+from poetry.repositories.auth import Auth
+from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.utils._compat import Path
 from poetry.utils.exporter import Exporter
 
@@ -33,7 +36,14 @@ def locker():
     return Locker()
 
 
-def test_exporter_can_export_requirements_txt_with_standard_packages(tmp_dir, locker):
+@pytest.fixture
+def pool():
+    return Pool()
+
+
+def test_exporter_can_export_requirements_txt_with_standard_packages(
+    tmp_dir, locker, pool
+):
     locker.mock_lock_data(
         {
             "package": [
@@ -59,7 +69,7 @@ def test_exporter_can_export_requirements_txt_with_standard_packages(tmp_dir, lo
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -75,7 +85,7 @@ foo==1.2.3
 
 
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes(
-    tmp_dir, locker
+    tmp_dir, locker, pool
 ):
     locker.mock_lock_data(
         {
@@ -102,7 +112,7 @@ def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes(
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -120,7 +130,7 @@ foo==1.2.3 \\
 
 
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes_disabled(
-    tmp_dir, locker
+    tmp_dir, locker, pool
 ):
     locker.mock_lock_data(
         {
@@ -147,7 +157,7 @@ def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes_
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir), with_hashes=False)
 
@@ -163,7 +173,7 @@ foo==1.2.3
 
 
 def test_exporter_exports_requirements_txt_without_dev_packages_by_default(
-    tmp_dir, locker
+    tmp_dir, locker, pool
 ):
     locker.mock_lock_data(
         {
@@ -190,7 +200,7 @@ def test_exporter_exports_requirements_txt_without_dev_packages_by_default(
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -206,7 +216,7 @@ foo==1.2.3 \\
 
 
 def test_exporter_exports_requirements_txt_with_dev_packages_if_opted_in(
-    tmp_dir, locker
+    tmp_dir, locker, pool
 ):
     locker.mock_lock_data(
         {
@@ -233,7 +243,7 @@ def test_exporter_exports_requirements_txt_with_dev_packages_if_opted_in(
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir), dev=True)
 
@@ -250,7 +260,7 @@ foo==1.2.3 \\
     assert expected == content
 
 
-def test_exporter_can_export_requirements_txt_with_git_packages(tmp_dir, locker):
+def test_exporter_can_export_requirements_txt_with_git_packages(tmp_dir, locker, pool):
     locker.mock_lock_data(
         {
             "package": [
@@ -274,7 +284,7 @@ def test_exporter_can_export_requirements_txt_with_git_packages(tmp_dir, locker)
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -288,7 +298,9 @@ def test_exporter_can_export_requirements_txt_with_git_packages(tmp_dir, locker)
     assert expected == content
 
 
-def test_exporter_can_export_requirements_txt_with_directory_packages(tmp_dir, locker):
+def test_exporter_can_export_requirements_txt_with_directory_packages(
+    tmp_dir, locker, pool
+):
     locker.mock_lock_data(
         {
             "package": [
@@ -308,7 +320,7 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(tmp_dir, l
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -322,7 +334,7 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(tmp_dir, l
     assert expected == content
 
 
-def test_exporter_can_export_requirements_txt_with_file_packages(tmp_dir, locker):
+def test_exporter_can_export_requirements_txt_with_file_packages(tmp_dir, locker, pool):
     locker.mock_lock_data(
         {
             "package": [
@@ -342,7 +354,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(tmp_dir, locker
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
 
     exporter.export("requirements.txt", Path(tmp_dir))
 
@@ -356,7 +368,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(tmp_dir, locker
     assert expected == content
 
 
-def test_exporter_exports_requirements_txt_with_legacy_packages(tmp_dir, locker):
+def test_exporter_exports_requirements_txt_with_legacy_packages(tmp_dir, locker, pool):
     locker.mock_lock_data(
         {
             "package": [
@@ -387,7 +399,8 @@ def test_exporter_exports_requirements_txt_with_legacy_packages(tmp_dir, locker)
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
+    pool.add_repository(LegacyRepository("bar", "https://example.com/simple/"))
 
     exporter.export("requirements.txt", Path(tmp_dir), dev=True)
 
@@ -395,7 +408,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages(tmp_dir, locker)
         content = f.read()
 
     expected = """\
---extra-index-url https://example.com/simple/
+--extra-index-url https://example.com/simple
 bar==4.5.6 \\
     --hash=sha256:67890
 foo==1.2.3 \\
@@ -406,7 +419,7 @@ foo==1.2.3 \\
 
 
 def test_exporter_exports_requirements_txt_with_multiple_legacy_packages(
-    tmp_dir, locker
+    tmp_dir, locker, pool
 ):
     locker.mock_lock_data(
         {
@@ -419,7 +432,7 @@ def test_exporter_exports_requirements_txt_with_multiple_legacy_packages(
                     "python-versions": "*",
                     "source": {
                         "type": "legacy",
-                        "url": "https://example2.com/simple/",
+                        "url": "https://user_john:passwd1234@example2.com/simple/",
                         "reference": "",
                     },
                 },
@@ -455,7 +468,12 @@ def test_exporter_exports_requirements_txt_with_multiple_legacy_packages(
             },
         }
     )
-    exporter = Exporter(locker)
+    exporter = Exporter(locker, pool)
+    pool.add_repository(LegacyRepository("repo_public", "https://example.com/simple/"))
+    auth = Auth("https://example2.com/simple/", "user_john", "passwd1234")
+    pool.add_repository(
+        LegacyRepository("repo_private", "https://example2.com/simple/", auth)
+    )
 
     exporter.export("requirements.txt", Path(tmp_dir), dev=True)
 
@@ -463,8 +481,8 @@ def test_exporter_exports_requirements_txt_with_multiple_legacy_packages(
         content = f.read()
 
     expected = """\
---extra-index-url https://example.com/simple/
---extra-index-url https://example2.com/simple/
+--extra-index-url https://example.com/simple
+--extra-index-url https://user_john:passwd1234@example2.com/simple
 bar==4.5.6 \\
     --hash=sha256:67890
 foo==1.2.3 \\


### PR DESCRIPTION
This pull request modifies the export of dependencies to `requirements.txt` format. 
The currently released implementation has problem with custom repositories. It exports custom repositories next to the given dependency which is not correct (see https://pip.readthedocs.io/en/1.1/requirements.html#indexes-find-links or https://github.com/pypa/pip/blob/master/src/pip/_internal/req/req_file.py#L131).

This PR changes current behavior in multiple ways. 
First, it puts all links to external dependencies to beginning of the output `requirements.txt` file. 
Next, it changes `--index-url` to `--extra-index-url` as `--extra-index-url` adds to the list of queried repositories instead of replacing the list. 
And finally, it adds credentials for respective repositories to the repository URL.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

