### PR TITLE
Use Python Version and OS to Select the Appropriate Wheel (#944)  {Against "master" Branch}

### DIFF
--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -445,9 +445,7 @@ class PyPiRepository(Repository):
         # Format the expected platform name as used by package authors
         os_map = {"windows": "win", "darwin": "macosx"}
         os_name = (
-            os_map[sys_info["plat"]]
-            if sys_info["plat"] in os_map
-            else sys_info["plat"]
+            os_map[sys_info["plat"]] if sys_info["plat"] in os_map else sys_info["plat"]
         )
         machine = sys_info["machine"]
         if os_name == "win" and machine == "x86":

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -451,7 +451,8 @@ class PyPiRepository(Repository):
         bit_label = "32" if sys_info["is32bit"] else "64"
         py_label = "cp{}".format("".join(sys_info["pyver"][:2]))
         self._log(
-            "Attempting to determine best match for: {}".format(sys_info), level="debug"
+            "Attempting to determine best wheel file for: {}".format(sys_info),
+            level="debug",
         )
 
         platform_matches = []
@@ -461,7 +462,12 @@ class PyPiRepository(Repository):
             if os_name in plat:
                 match_py = m.group("pyver") == py_label
                 if match_py and (bit_label in plat or "x86_64" in plat):
-                    self._log("Found best wheel match: {}".format(url), level="debug")
+                    self._log(
+                        "Selected best platform, bit, and Python version match: {}".format(
+                            url
+                        ),
+                        level="debug",
+                    )
                     return url
                 elif match_py:
                     platform_matches.insert(0, url)

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -95,14 +95,13 @@ class PyPiRepository(Repository):
         """
         Return dictionary describing the OS and Python configuration.
         """
-        if self._sys_info:
-            return self._sys_info
-        self._sys_info = {
-            "plat": platform.system().lower(),
-            "is32bit": sys.maxsize <= 2 ** 32,
-            "imp_name": sys.implementation.name,
-            "pyver": platform.python_version_tuple(),
-        }
+        if not hasattr(self, "_sys_info"):
+            self._sys_info = {
+                "plat": platform.system().lower(),
+                "is32bit": sys.maxsize <= 2 ** 32,
+                "imp_name": sys.implementation.name,
+                "pyver": platform.python_version_tuple(),
+            }
         return self._sys_info
 
     def find_packages(

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -49,11 +49,7 @@ class MockRepository(PyPiRepository):
 
     def get_sys_info(self):
         # Mock different hardware configurations by overriding this method
-        return {
-            "plat": self.plat.lower(),
-            "is32bit": self.is32bit,
-            "pyver": self.pyver,
-        }
+        return {"plat": self.plat.lower(), "is32bit": self.is32bit, "pyver": self.pyver}
 
 
 def test_find_packages():

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -13,13 +13,13 @@ class MockRepository(PyPiRepository):
     JSON_FIXTURES = Path(__file__).parent / "fixtures" / "pypi.org" / "json"
     DIST_FIXTURES = Path(__file__).parent / "fixtures" / "pypi.org" / "dists"
 
-    def __init__(self, fallback=False, plat="Linux", machine="amd64", pyver=(3, 7, 2)):
+    def __init__(self, fallback=False, plat="Linux", is32bit=True, pyver=(3, 7, 2)):
         super(MockRepository, self).__init__(
             url="http://foo.bar", disable_cache=True, fallback=fallback
         )
 
         self.plat = plat
-        self.machine = machine
+        self.is32bit = is32bit
         self.pyver = pyver
 
     def _get(self, url):
@@ -51,7 +51,7 @@ class MockRepository(PyPiRepository):
         # Mock different hardware configurations by overriding this method
         return {
             "plat": self.plat.lower(),
-            "machine": self.machine.lower(),
+            "is32bit": self.is32bit,
             "pyver": self.pyver,
         }
 
@@ -155,29 +155,29 @@ numpy_plat_spec_wheels = [
 
 
 @pytest.mark.parametrize(
-    "plat,machine,pyver,best_wheel",
+    "plat,is32bit,pyver,best_wheel",
     [
         (
             "Linux",
-            "x86_64",
+            False,
             ("3", "7", "2"),
             "numpy-1.16.2-cp37-cp37m-manylinux1_x86_64.whl",
         ),
         (
             "Darwin",
-            "x86_64",
+            False,
             ("2", "7", "3"),
             (
                 "numpy-1.16.2-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel."
                 "macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl"
             ),
         ),
-        ("Windows", "AMD64", ("3", "6", "2"), "numpy-1.16.2-cp36-cp36m-win_amd64.whl"),
-        ("Windows", "32", ("3", "5", "0a1"), "numpy-1.16.2-cp35-cp35m-win32.whl"),
+        ("Windows", False, ("3", "6", "2"), "numpy-1.16.2-cp36-cp36m-win_amd64.whl"),
+        ("Windows", True, ("3", "5", "0a1"), "numpy-1.16.2-cp35-cp35m-win32.whl"),
     ],
 )
-def test_fallback_selects_correct_platform_wheel(plat, machine, pyver, best_wheel):
-    repo = MockRepository(fallback=True, plat=plat, machine=machine, pyver=pyver)
+def test_fallback_selects_correct_platform_wheel(plat, is32bit, pyver, best_wheel):
+    repo = MockRepository(fallback=True, plat=plat, is32bit=is32bit, pyver=pyver)
     assert best_wheel == repo._pick_platform_specific_wheel(numpy_plat_spec_wheels)
 
 

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -20,10 +20,13 @@ class MockRepository(PyPiRepository):
             url="http://foo.bar", disable_cache=True, fallback=fallback
         )
 
-        self.plat = plat
-        self.is32bit = is32bit
-        self.imp_name = imp_name
-        self.pyver = pyver
+        # Mock different hardware configurations
+        self._sys_info = {
+            "plat": plat.lower(),
+            "is32bit": is32bit,
+            "imp_name": imp_name,
+            "pyver": pyver,
+        }
 
     def _get(self, url):
         parts = url.split("/")[1:]
@@ -49,15 +52,6 @@ class MockRepository(PyPiRepository):
         fixture = self.DIST_FIXTURES / filename
 
         shutil.copyfile(str(fixture), dest)
-
-    def get_sys_info(self):
-        # Mock different hardware configurations by overriding this method
-        return {
-            "plat": self.plat.lower(),
-            "is32bit": self.is32bit,
-            "imp_name": self.imp_name,
-            "pyver": self.pyver,
-        }
 
 
 def test_find_packages():


### PR DESCRIPTION
Resolves #944 & #807 

**Issue**: If a package only has `platform_specific_wheels`, Poetry just downloads the first one, which is usually cp27 and MacOSX (i.e.: [numpy](https://pypi.org/project/numpy/#files))

**Changes**: This PR adds logic to determine the best wheel file to download for [Poetry supported platforms](https://poetry.eustace.io/docs/#system-requirements). If the best wheel can't be identified, the method falls back on the original behavior to return the first platform wheel. This fixes the *[OS Error]* on Windows and improves matching for Linux and Mac.

Also, tested on a couple of different computers as a sanity check (Win7-64, Win10-64, and MacOSX Mojave)

# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code. {N/A - no changes necessary}
