### PR TITLE
add reqs-to-pyproject script

### DIFF
--- a/reqs-to-pyproject.py
+++ b/reqs-to-pyproject.py
@@ -1,0 +1,38 @@
+import sys
+from pip._internal.req.req_file import preprocess, process_line
+
+
+def main():
+    filename = sys.argv[1]
+    with open(filename, 'r') as f:
+        content = f.read()
+
+    reqs = []
+    for n, line in preprocess(content, None):
+        for req in process_line(line, filename, n):
+            reqs.append(req)
+
+    deps = reqs_to_poetry_deps(reqs)
+
+    print('\n'.join(deps))
+
+
+def reqs_to_poetry_deps(reqs):
+    deps = []
+    for req in reqs:
+        r = req.req
+        #print(dir(r.specifier._specs), dir(r.specifier))
+        specs = r.specifier
+        if len(specs._specs) > 0:
+            spec = next(iter(specs._specs))
+            #print(dir(spec))
+            #print(spec.version, spec.operator)
+            dep = '{} = "{}"'.format(r.name, spec)
+        else:
+            dep = ''
+        deps.append(dep)
+    return deps
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script converts requirments.txt to pyproject dependencies
specifications. it is not intended to be a standalone script, but a part
of poetry init process, or a certain poetry command. This commit only
gives a scratch of the core work that is essential for the purpose.

Calling script with a requirements.txt file will produce stdout like this:

```
Django = "==1.11.17"
MySQL-python = "==1.2.5"
Pillow = "==3.2.0"
apibox = ">=0.2.0"
arrow = "==0.7.0"
boto3 = "==1.4.5"
dictate = ">=0.2.0"
gevent = "==1.2.0"
jsonfield = "==1.0.3"
jsonschema = "==2.5.1"
params = ">=0.3.0"
protobuf = "==3.2.0"
pypinyin = "==0.12.1"
python-dateutil = "==2.6.0"
pytz = "==2016.7"
redis = "==2.10.5"
requests = "==2.11.1"
retrying = "==1.3.3"
```

Users could then paste it to pyproject deps section, and edit as they need.