### PR TITLE
Fix AttributeError on accessing package author (#370)

### DIFF
--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -138,10 +138,13 @@ class Package(object):
         return self.requires + self.dev_requires
 
     def _get_author(self):  # type: () -> dict
+        default = {"name": None, "email": None}
         if not self._authors:
-            return {"name": None, "email": None}
+            return default
 
         m = AUTHOR_REGEX.match(self._authors[0])
+        if not m:
+            return default
 
         name = m.group("name")
         email = m.group("email")

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -15,6 +15,7 @@ def test_package_authors():
     assert package.author_name == "John Doe"
     assert package.author_email is None
 
+
 def test_author_email_only():
     """
     Checks Package for correct handling of unparsable authors

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -5,15 +5,25 @@ import pytest
 
 from poetry.packages import Package
 
+AUTHORS = (
+    "Sébastien Eustace <sebastien@eustace.io>",
+    "Sébastien Eustace<sebastien@eustace.io>",
+    "Sébastien Eustace sebastien@eustace.io",
+)
 
-def test_package_authors():
+
+@pytest.mark.parametrize("author", AUTHORS)
+def test_package_authors(author):
     package = Package("foo", "0.1.0")
 
-    package.authors.append("Sébastien Eustace <sebastien@eustace.io>")
+    package.authors.append(author)
     assert package.author_name == "Sébastien Eustace"
     assert package.author_email == "sebastien@eustace.io"
 
-    package.authors[0] = "John Doe"
+
+def test_author_name():
+    package = Package("foo", "0.1.0")
+    package.authors.append("John Doe")
     assert package.author_name == "John Doe"
     assert package.author_email is None
 

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -1,26 +1,41 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from poetry.packages import Package
 
 
-def test_package_authors():
+AUTHORS = (
+    "Sébastien Eustace <sebastien@eustace.io>",
+    "Sébastien Eustace<sebastien@eustace.io>",
+    "Sébastien Eustace sebastien@eustace.io",
+)
+
+
+@pytest.mark.parametrize("author", AUTHORS)
+def test_package_authors(author):
     package = Package("foo", "0.1.0")
 
-    package.authors.append("Sébastien Eustace <sebastien@eustace.io>")
+    package.authors.append(author)
     assert package.author_name == "Sébastien Eustace"
     assert package.author_email == "sebastien@eustace.io"
 
-    package.authors.insert(0, "John Doe")
-    assert package.author_name == "John Doe"
-    assert package.author_email is None
 
-
-def test_author_email_only():
+def test_author_partial():
     """
-    Checks Package for correct handling of email only authors
+    Checks Package for correct handling of partial authors
+    (email only, for example)
     """
     package = Package("foo", "0.1.0")
     package.authors.append("support@example.com")
-    assert not package.author_name
-    assert package.author_email
+    assert package.author_name is None
+    assert package.author_email == "support@example.com"
+
+    package.authors[0] = "<support@example.com>"
+    assert package.author_name is None
+    assert package.author_email == "support@example.com"
+
+    package.authors[0] = "John Doe"
+    assert package.author_name == "John Doe"
+    assert package.author_email is None

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -1,40 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import pytest
-
 from poetry.packages import Package
 
 
-AUTHORS = (
-    "Sébastien Eustace <sebastien@eustace.io>",
-    "Sébastien Eustace<sebastien@eustace.io>",
-    "Sébastien Eustace sebastien@eustace.io",
-)
-
-
-@pytest.mark.parametrize("author", AUTHORS)
-def test_package_authors(author):
+def test_package_authors():
     package = Package("foo", "0.1.0")
 
-    package.authors.append(author)
+    package.authors.append("Sébastien Eustace <sebastien@eustace.io>")
     assert package.author_name == "Sébastien Eustace"
     assert package.author_email == "sebastien@eustace.io"
-
-
-def test_author_partial():
-    """
-    Checks Package for correct handling of partial authors
-    (email only, for example)
-    """
-    package = Package("foo", "0.1.0")
-    package.authors.append("support@example.com")
-    assert package.author_name is None
-    assert package.author_email == "support@example.com"
-
-    package.authors[0] = "<support@example.com>"
-    assert package.author_name is None
-    assert package.author_email == "support@example.com"
 
     package.authors[0] = "John Doe"
     assert package.author_name == "John Doe"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -14,3 +14,12 @@ def test_package_authors():
     package.authors.insert(0, "John Doe")
     assert package.author_name == "John Doe"
     assert package.author_email is None
+
+def test_author_email_only():
+    """
+    Checks Package for correct handling of unparsable authors
+    (email only for example)
+    """
+    package = Package("foo", "0.1.0")
+    package.authors.append("<support@example.com>")
+    assert not package.author_name

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from poetry.packages import Package
 
 
@@ -14,3 +16,10 @@ def test_package_authors():
     package.authors[0] = "John Doe"
     assert package.author_name == "John Doe"
     assert package.author_email is None
+
+
+def test_invalid_author():
+    package = Package("foo", "0.1.0")
+    package.authors.append("support@example.com")
+    with pytest.raises(ValueError):
+        assert package.author_name

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -18,10 +18,9 @@ def test_package_authors():
 
 def test_author_email_only():
     """
-    Checks Package for correct handling of unparsable authors
-    (email only for example)
+    Checks Package for correct handling of email only authors
     """
     package = Package("foo", "0.1.0")
-    package.authors.append("<support@example.com>")
+    package.authors.append("support@example.com")
     assert not package.author_name
-    assert not package.author_email
+    assert package.author_email

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -24,3 +24,4 @@ def test_author_email_only():
     package = Package("foo", "0.1.0")
     package.authors.append("<support@example.com>")
     assert not package.author_name
+    assert not package.author_email


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

There is fix for #370, when `poetry build` crashed on accessing incorrect author fields.

Also, I could change `AUTHOR_REGEX` to support for email-only authors, but I don't think there is need to handle those situations. At least it's not crashing right now. 

Or maybe better throw warning on authors like that?