### PR TITLE
Fix bug where path dependencies always install in editable mode

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -381,6 +381,8 @@ class Provider:
         package.source_type = "directory"
         package.source_url = dependency.path.as_posix()
 
+        package.develop = dependency.develop
+
         for extra in dependency.extras:
             if extra in package.extras:
                 for dep in package.extras[extra]:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -282,6 +282,20 @@ def test_search_for_directory_poetry_with_extras(provider):
     }
 
 
+def test_search_for_directory_poetry_develop_false(provider):
+    dependency = DirectoryDependency(
+        "demo",
+        Path(__file__).parent.parent / "fixtures" / "simple_project",
+        develop=False,
+    )
+
+    package = provider.search_for_directory(dependency)[0]
+
+    assert package.name == "simple-project"
+    assert package.version.text == "1.2.3"
+    assert package.develop is False
+
+
 def test_search_for_file_sdist(provider):
     dependency = FileDependency(
         "demo",


### PR DESCRIPTION
The state of the develop constraint wasn't being passed through when
path based directory dependencies are resolved into specific
packages to install, leading to them always being installed in
editable mode (the default).

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!