### PR TITLE
Fix UnicodeDecodeError caused by opening README with no encoding

### DIFF
--- a/poetry/masonry/metadata.py
+++ b/poetry/masonry/metadata.py
@@ -46,7 +46,7 @@ class Metadata:
         meta.version = normalize_version(package.version.text)
         meta.summary = package.description
         if package.readme:
-            with package.readme.open() as f:
+            with package.readme.open(encoding="utf-8") as f:
                 meta.description = f.read()
 
         meta.keywords = ",".join(package.keywords)


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes #1027 by opening the README with the UTF-8 encoding, instead of the default encoding for the platform. I looked at the tests that exist, and the test_builder and test_complete already do quite a bit of testing around importing a description from a README. Would it be worth creating unicode characters in the "complete" README.rst?
