### PR TITLE
[WIP] Allow to manage project version with git tags

### DIFF
--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -21,6 +21,7 @@ from .spdx import license_by_id
 from .utils._compat import Path
 from .utils.helpers import get_http_basic_auth
 from .utils.toml_file import TomlFile
+from .vcs.git import version_from_tags
 
 
 class Poetry:
@@ -107,7 +108,7 @@ class Poetry:
 
         # Load package
         name = local_config["name"]
-        version = local_config["version"]
+        version = local_config.get("version", version_from_tags())
         package = ProjectPackage(name, version, version)
         package.root_dir = poetry_file.parent
 

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pkg_resources
 import re
 import subprocess
 
@@ -43,6 +44,9 @@ class Git:
 
     def clone(self, repository, dest):  # type: (...) -> str
         return self.run("clone", repository, str(dest))
+
+    def tag(self):  # type: (...) -> list
+        return self.run("tag").split("\n")
 
     def checkout(self, rev, folder=None):  # type: (...) -> str
         args = []
@@ -100,3 +104,14 @@ class Git:
         return decode(
             subprocess.check_output(["git"] + list(args), stderr=subprocess.STDOUT)
         )
+
+
+def version_from_tags():
+    from poetry.semver import Version
+
+    git = Git()
+    version = "0.0.0"
+    tags = git.tag()
+    if tags:
+        version = max(tags, key=pkg_resources.parse_version)
+    return Version.parse(version)


### PR DESCRIPTION
To avoid to manage textual version of a project allow poetry
to retrieve those informations directly from git tags.

To determine the current version number we currently retrieve
the highest available tag number.

If the version is not available in the pyproject.toml then
poetry try to retrieve version from git so project can continue
to manage these informations manually.

If the version is not available in the pyproject.toml and if
it's not a git repository then an exception is raised and we
retrieve the previous behavior of poetry.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
