### PR TITLE
Fix installation breakage with pip 19+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _build
 *.so
 
 # Installer logs
+pip-wheel-metadata/
 pip-log.txt
 
 # Unit test / coverage reports

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -86,7 +86,7 @@ exist it will look for <comment>pyproject.toml</> and do the same.
                 f.write(decode(builder.build_setup()))
 
         try:
-            self.env.run("pip", "install", "-e", str(setup.parent), "--no-deps")
+            self.env.run("python", str(setup), "develop", "--no-deps")
         finally:
             if not has_setup:
                 os.remove(str(setup))

--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -22,7 +22,7 @@ from .builder import Builder
 
 SETUP = """\
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+from setuptools import setup
 
 {before}
 setup_kwargs = {{


### PR DESCRIPTION
- [x] Added **tests** for changed code. (not necessary, same interface)
- [X] Updated **documentation** for changed code. (not necessary, same interface)

This PR fixes bugs installing a poetry package locally with pip >= version 19 installed.

"pip install -e . --no-deps" is replaced with "python setup.py develop --no-deps" to work around pip 19's strict adherence to pip 517. Basically, we can't install in editable mode with pip if a pyproject.toml is present. See: https://github.com/pypa/pip/pull/6331

This commit proposes an alternative approach. Since "pip install -e" implicitly uses setuptools's "develop" mode under the hood, we simply invoke setuptools directly, bypassing pip's correct handling of PEP 517, and adding setuptools to the autogenerated setup.py (necessary to get it to work).

For proof of setuptools's "develop" mode being used under pip's hood: https://github.com/pypa/pip/blob/master/src/pip/_internal/req/req_install.py#L739

Note: like "pip install -e", "python setup.py develop --no-deps" feels like a hack. In the future, we may consider working toward not relying on setuptools / distutils for local installation.

Resolves / deprecates (probably more, there is a lot of complaining about pip version 19): 

* https://github.com/sdispater/poetry/issues/866
* https://github.com/sdispater/poetry/issues/896
* (I think) https://github.com/sdispater/poetry/issues/825
* (not necessary) https://github.com/bryanforbes/botus_receptus/commit/279342a3654d2c307fa9db505aed59a874e7d061