### PR TITLE
[FIX] activation of venv, when `.venv` is a file

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -184,7 +184,7 @@ class Env(object):
 
         if not in_venv:
             # Checking if a local virtualenv exists
-            if (cwd / ".venv").exists():
+            if (cwd / ".venv").exists() and (cwd / ".venv").is_dir():
                 venv = cwd / ".venv"
 
                 return VirtualEnv(venv)


### PR DESCRIPTION
Some programs (ex. Emacs with auto-virtualenvwrapper package) uses
.venv file to auto-determine the virtualenv of the project. Which is
pretty handy. As well as, it doesn't make sense inside a poetry to
try to set the venv, when it is a file.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
