### PR TITLE
Add pew-style project management

### DIFF
--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -33,6 +33,7 @@ from .commands.self import SelfCommand
 
 from .config import ApplicationConfig
 
+from .commands.alias import AliasCommand
 from .commands.env import EnvCommand
 
 
@@ -90,6 +91,9 @@ class Application(BaseApplication):
 
         # Debug command
         commands += [DebugCommand()]
+
+        # Alias command
+        commands += [AliasCommand()]
 
         # Env command
         commands += [EnvCommand()]

--- a/poetry/console/commands/alias/__init__.py
+++ b/poetry/console/commands/alias/__init__.py
@@ -1,0 +1,1 @@
+from .alias import AliasCommand

--- a/poetry/console/commands/alias/alias.py
+++ b/poetry/console/commands/alias/alias.py
@@ -1,5 +1,6 @@
 from ..command import Command
 
+from .clean import AliasCleanCommand
 from .go import AliasGoCommand
 from .list import AliasListCommand
 from .prune import AliasPruneCommand
@@ -16,6 +17,7 @@ class AliasCommand(Command):
     """
 
     commands = [
+        AliasCleanCommand(),
         AliasGoCommand(),
         AliasListCommand(),
         AliasPruneCommand(),

--- a/poetry/console/commands/alias/alias.py
+++ b/poetry/console/commands/alias/alias.py
@@ -1,0 +1,26 @@
+from ..command import Command
+
+from .go import AliasGoCommand
+from .list import AliasListCommand
+from .rm import AliasRmCommand
+from .set import AliasSetCommand
+from .show import AliasShowCommand
+
+
+class AliasCommand(Command):
+    """
+    Work with Poetry's project aliases.
+
+    alias
+    """
+
+    commands = [
+        AliasGoCommand(),
+        AliasListCommand(),
+        AliasRmCommand(),
+        AliasSetCommand(),
+        AliasShowCommand(),
+    ]
+
+    def handle(self):  # type: () -> int
+        return self.call("help", self._config.name)

--- a/poetry/console/commands/alias/alias.py
+++ b/poetry/console/commands/alias/alias.py
@@ -2,6 +2,7 @@ from ..command import Command
 
 from .go import AliasGoCommand
 from .list import AliasListCommand
+from .prune import AliasPruneCommand
 from .rm import AliasRmCommand
 from .set import AliasSetCommand
 from .show import AliasShowCommand
@@ -17,6 +18,7 @@ class AliasCommand(Command):
     commands = [
         AliasGoCommand(),
         AliasListCommand(),
+        AliasPruneCommand(),
         AliasRmCommand(),
         AliasSetCommand(),
         AliasShowCommand(),

--- a/poetry/console/commands/alias/clean.py
+++ b/poetry/console/commands/alias/clean.py
@@ -1,0 +1,23 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasCleanCommand(Command):
+    """
+    Remove all alias definitions that no longer point to a project directory.
+
+    clean
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager()
+        removed_aliases = manager.clean()
+
+        if not removed_aliases:
+            self.line("No aliases defined.")
+            return 0
+
+        self.line("<b>Removed Aliases</b>")
+        for name in sorted(removed_aliases):
+            self.line("<info>{}</info>: {}".format(name, removed_aliases[name]))

--- a/poetry/console/commands/alias/go.py
+++ b/poetry/console/commands/alias/go.py
@@ -1,0 +1,40 @@
+import sys
+
+from os import chdir, environ
+from distutils.util import strtobool
+
+from poetry.utils._compat import Path
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasGoCommand(Command):
+    """
+    Activate a project's virtualenv and change to its source directory.
+
+    go
+        {name : The alias of the project to activate.}
+    """
+
+    def handle(self):  # type: () -> None
+        # Don't do anything if we are already inside a virtualenv
+        active_venv = environ.get("VIRTUAL_ENV", None)
+
+        if active_venv is not None:
+            self.line(
+                "Virtual environment already activated: "
+                "<info>{}</>".format(active_venv)
+            )
+            return
+
+        # Determine the project path for the given alias
+        manager = AliasManager()
+        name = self.argument("name")
+        project_path = manager.get_project(name)
+        project_dirname = str(project_path)
+
+        # Change directory and activate the virtualenv
+        chdir(project_dirname)
+        environ["PWD"] = project_dirname
+        self.call("shell")

--- a/poetry/console/commands/alias/list.py
+++ b/poetry/console/commands/alias/list.py
@@ -1,0 +1,18 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasListCommand(Command):
+    """
+    List all defined project aliases.
+
+    list
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager()
+        aliases = manager.list()
+
+        for name in sorted(aliases):
+            self.line("<info>{}</info>: {}".format(name, aliases[name]))

--- a/poetry/console/commands/alias/prune.py
+++ b/poetry/console/commands/alias/prune.py
@@ -1,0 +1,23 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasPruneCommand(Command):
+    """
+    Remove all alias definitions that no longer point to a project directory.
+
+    prune
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager()
+        removed_aliases = manager.prune()
+
+        if not removed_aliases:
+            self.line("No dangling aliases found.")
+            return 0
+
+        self.line("<b>Removed Aliases</b>")
+        for name in sorted(removed_aliases):
+            self.line("<info>{}</info>: {}".format(name, removed_aliases[name]))

--- a/poetry/console/commands/alias/rm.py
+++ b/poetry/console/commands/alias/rm.py
@@ -1,0 +1,23 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasRmCommand(Command):
+    """
+    Remove the alias for the current project.
+
+    rm
+        {alias? : The alias to remove.  If omitted, remove the current project's alias.}
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager()
+        alias = self.argument("alias")
+
+        if alias:
+            project_path = manager.get_project(alias)
+        else:
+            project_path = self.poetry.file.parent
+
+        manager.remove(project_path)

--- a/poetry/console/commands/alias/set.py
+++ b/poetry/console/commands/alias/set.py
@@ -1,0 +1,18 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasSetCommand(Command):
+    """
+    Set an alias for the current project.
+
+    set
+        {name : The alias to set for the current project.}
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager(self.poetry.config)
+        project_path = self.poetry.file.parent
+        name = self.argument("name")
+        manager.set(project_path, name)

--- a/poetry/console/commands/alias/show.py
+++ b/poetry/console/commands/alias/show.py
@@ -1,0 +1,17 @@
+from poetry.utils.alias import AliasManager
+
+from ..command import Command
+
+
+class AliasShowCommand(Command):
+    """
+    Show the alias for the current project.
+
+    show
+    """
+
+    def handle(self):  # type: () -> None
+        manager = AliasManager(self.poetry.config)
+        project_path = self.poetry.file.parent
+        name = manager.get_alias(project_path)
+        self.line(name)

--- a/poetry/utils/alias.py
+++ b/poetry/utils/alias.py
@@ -1,0 +1,97 @@
+import tomlkit
+
+from typing import Dict
+
+from poetry.config import Config
+from poetry.locations import CACHE_DIR
+from poetry.utils._compat import Path
+from poetry.utils.toml_file import TomlFile
+
+
+class AliasManager(object):
+    """
+    Project aliases manager.
+    """
+
+    def __init__(self, config=None):  # type: (Config) -> None
+        if config is None:
+            config = Config.create("config.toml")
+
+        venv_path = config.setting("settings.virtualenvs.path")
+        if venv_path is None:
+            venv_path = Path(CACHE_DIR) / "virtualenvs"
+        else:
+            venv_path = Path(venv_path)
+
+        self.aliases_file = TomlFile(venv_path / "aliases.toml")
+        self.aliases = tomlkit.document()
+
+        if self.aliases_file.exists():
+            self.aliases = self.aliases_file.read()
+
+    def list(self):  # type: () -> Dict[str, str]
+        """
+        Return a list of all project alias definitions.
+        """
+        return {name: project for name, project in self.aliases.items()}
+
+    def get_alias(self, project_path):  # type: (Path) -> str
+        """
+        Get the alias for a given project.
+        """
+        project_dirname = str(project_path)
+
+        for n, p in self.aliases.items():
+            if p == project_dirname:
+                return n
+
+        raise AliasCommandError("No alias defined for the project")
+
+    def get_project(self, name):  # type: (str) -> Path
+        """
+        Get the project path for a given alias.
+        """
+        try:
+            project_dirname = self.aliases[name]
+        except KeyError:
+            raise AliasCommandError("Unknown project alias: {}".format(name))
+
+        return Path(project_dirname)
+
+    def remove(self, project_path):  # type: (Path) -> None
+        """
+        Remove aliase(es) for a project.
+        """
+        project_dirname = str(project_path)
+
+        for n, p in self.aliases.items():
+            if p == project_dirname:
+                del self.aliases[n]
+
+        self.aliases_file.write(self.aliases)
+
+    def set(self, project_path, name):  # type: (Path, str) -> None
+        """
+        Set an alias for a project.
+        """
+        project_dirname = str(project_path)
+
+        # Check the the alias isn't already used for a different project
+        existing_project = self.aliases.get(name, None)
+
+        if existing_project is not None and existing_project != project_dirname:
+            raise AliasCommandError(
+                'Alias "{}" already exists for project {}'.format(
+                    name, existing_project
+                )
+            )
+
+        # Add alias to the aliases file
+        self.remove(project_path)
+        self.aliases[name] = project_dirname
+        self.aliases_file.write(self.aliases)
+
+
+class AliasCommandError(Exception):
+
+    pass

--- a/poetry/utils/alias.py
+++ b/poetry/utils/alias.py
@@ -109,6 +109,18 @@ class AliasManager(object):
         self.aliases_file.write(self.aliases)
         return removed_aliases
 
+    def clean(self):  # type: () -> Dict[str, str]
+        """
+        Remove all alias definitions.
+        """
+        removed_aliases = self.list()
+
+        for name, project_dirname in self.aliases.items():
+            del self.aliases[name]
+
+        self.aliases_file.write(self.aliases)
+        return removed_aliases
+
 
 class AliasCommandError(Exception):
 

--- a/poetry/utils/alias.py
+++ b/poetry/utils/alias.py
@@ -91,6 +91,24 @@ class AliasManager(object):
         self.aliases[name] = project_dirname
         self.aliases_file.write(self.aliases)
 
+    def prune(self):  # type: () -> Dict[str, str]
+        """
+        Clean up dangling aliases.
+        """
+        removed_aliases = {}
+
+        for name, project_dirname in self.aliases.items():
+            poetry_file = Path(project_dirname) / "pyproject.toml"
+
+            if poetry_file.exists():
+                continue
+
+            del self.aliases[name]
+            removed_aliases[name] = project_dirname
+
+        self.aliases_file.write(self.aliases)
+        return removed_aliases
+
 
 class AliasCommandError(Exception):
 


### PR DESCRIPTION
This PR is a first attempt at addressing the feature request from issue #704.  I did not yet add/fix tests or add documentation, as I would first appreciate some feedback on (a) whether this is welcome at all, and (b) if yes, whether this PR is headed in the right direction.

# Summary

This PR introduces a new `alias` command suite:

  * `poetry alias set fnord` – define “fnord” as alias for the current project.  If a different project already used “fnord” as its alias, the command would abort with a corresponding error message.  Note: only one alias can be defined per project—i.e., if `poetry alias set ...` was called again, the current project’s alias would effectively be renamed.

  * `poetry alias show` – show the alias that has been defined for the current project.

  * `poetry alias list` – list all project aliases in alphabetical order along with their assigned project directories.

  * `poetry alias go fnord` – change to the directory of the project aliased “fnord” and execute `poetry shell` there to activate the virtualenv.  This only works if not already inside an activated virtualenv.

  * `poetry alias rm fnord` – remove the “fnord” project alias.  The alias name is optional for this command; if omitted, the current project’s alias will be removed.

  * `poetry alias prune` – remove all aliases that no longer point to a project directory.

  * `poetry alias clean` – remove all alias definitions.

Additionally, `poetry init` now also asks for a project alias, with the package name being the default value for it.  Users can enter a period `.` if they do not want to set an alias this way.

Internally, all aliases are centrally stored in an `aliases.toml` file in the virtualenv cache directory, next to `envs.toml`.  This PR’s central piece is the `poetry.utils.alias.AliasManager` class, with the console commands being thin wrappers around its functionality.


# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.