### PR TITLE
use symlinks in created venv by default on non-windows platforms. 

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -276,7 +276,13 @@ class Env(object):
         try:
             from venv import EnvBuilder
 
-            builder = EnvBuilder(with_pip=True)
+            # use the same defaults as python -m venv
+            if os.name == "nt":
+                use_symlinks = False
+            else:
+                use_symlinks = True
+
+            builder = EnvBuilder(with_pip=True, symlinks=use_symlinks)
             build = builder.create
         except ImportError:
             # We fallback on virtualenv for Python 2.7

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -24,3 +24,17 @@ def test_env_get_in_project_venv(tmp_dir, environ):
     venv = Env.get(cwd=Path(tmp_dir))
 
     assert venv.path == Path(tmp_dir) / ".venv"
+
+
+def test_env_has_symlinks_on_nix(tmp_dir):
+    venv_path = Path(tmp_dir) / "Virtual Env"
+
+    Env.build_venv(str(venv_path))
+
+    venv = VirtualEnv(venv_path)
+
+    if os.name == "nt":
+        assert not os.path.islink(venv.python)
+    else:
+        print(venv.python)
+        assert os.path.islink(venv.python)

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -33,8 +33,13 @@ def test_env_has_symlinks_on_nix(tmp_dir):
 
     venv = VirtualEnv(venv_path)
 
-    if os.name == "nt":
-        assert not os.path.islink(venv.python)
-    else:
-        print(venv.python)
+    venv_available = False
+    try:
+        from venv import EnvBuilder
+
+        venv_available = True
+    except ImportError:
+        pass
+
+    if os.name != "nt" and venv_available:
         assert os.path.islink(venv.python)


### PR DESCRIPTION
Fixes issue #779

As per the issue comments the change has Poetry align with normal python -m venv behavior.  As seen [here](https://github.com/python/cpython/blob/d8080c01195cc9a19af752bfa04d98824dd9fb15/Lib/venv/__init__.py#L368-L371). ie - the python binary in the new venv will be created as a symlink on non-windows platforms.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
