### PR TITLE
Use consistent package naming in example

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -98,7 +98,7 @@ you can specify the packages you want to include in the final distribution.
 [tool.poetry]
 # ...
 packages = [
-    { include = "mypackage" },
+    { include = "my_package" },
     { include = "extra_package/**/*.py" },
 ]
 ```
@@ -109,7 +109,7 @@ If your package is stored inside a "source" directory, you must specify it:
 [tool.poetry]
 # ...
 packages = [
-    { include = "mypackage", from = "lib" },
+    { include = "my_package", from = "lib" },
 ]
 ```
 
@@ -123,7 +123,7 @@ packages = [
 
     ```toml
     packages = [
-        { include = "mypackage" },
+        { include = "my_package" },
         { include = "extra_package" },
     ]
     ```


### PR DESCRIPTION
The description of the last example doesn't match the example, and the name `mypackage` doesn't match the style of `extra_package`, so I just made it `my_package` everywhere.