### PR TITLE
Fix encoding for files created for building package (issue #1027)

### DIFF
--- a/poetry/masonry/api.py
+++ b/poetry/masonry/api.py
@@ -39,13 +39,13 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     dist_info.mkdir()
 
     if "scripts" in poetry.local_config or "plugins" in poetry.local_config:
-        with (dist_info / "entry_points.txt").open("w") as f:
+        with (dist_info / "entry_points.txt").open("w", encoding="utf-8") as f:
             builder._write_entry_points(f)
 
-    with (dist_info / "WHEEL").open("w") as f:
+    with (dist_info / "WHEEL").open("w", encoding="utf-8") as f:
         builder._write_wheel_file(f)
 
-    with (dist_info / "METADATA").open("w") as f:
+    with (dist_info / "METADATA").open("w", encoding="utf-8") as f:
         builder._write_metadata_file(f)
 
     return dist_info.name

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -117,11 +117,11 @@ My Package
         assert (dist_info / "WHEEL").exists()
         assert (dist_info / "METADATA").exists()
 
-        with (dist_info / "entry_points.txt").open() as f:
+        with (dist_info / "entry_points.txt").open(encoding="utf-8") as f:
             assert entry_points == decode(f.read())
 
-        with (dist_info / "WHEEL").open() as f:
+        with (dist_info / "WHEEL").open(encoding="utf-8") as f:
             assert wheel_data == decode(f.read())
 
-        with (dist_info / "METADATA").open() as f:
+        with (dist_info / "METADATA").open(encoding="utf-8") as f:
             assert metadata == decode(f.read())


### PR DESCRIPTION
This is minimal set of modifications, which fixed the problem.

There are still more places, where files are open in text mode
without explicit encoding, thus possibly failing on systems not using
UTF-8 console encoding.

Created  by @vlcinsky and @rhorenov