### PR TITLE
Add `--all-extras` option to the install command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -117,11 +117,17 @@ poetry install --no-dev
 ```
 
 You can also specify the extras you want installed
-by passing the `--E|--extras` option (See [Extras](#extras) for more info)
+by passing the `--E|--extras` option
 
 ```bash
 poetry install --extras "mysql pgsql"
 poetry install -E mysql -E pgsql
+```
+
+Alternatively to install all available extras, pass the `--all-extras` option.
+
+```bash
+poetry install --all-extras
 ```
 
 By default `poetry` will install your project's package everytime you run `install`:
@@ -147,6 +153,7 @@ poetry install --no-root
 * `--no-dev`: Do not install dev dependencies.
 * `--no-root`: Do not install the root package (your project).
 * `--extras (-E)`: Features to install (multiple values allowed).
+* `--all-extras`: Install all available features (overrides `--extras`)
 
 ## update
 

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -27,6 +27,11 @@ class InstallCommand(EnvCommand):
             multiple=True,
         ),
         option(
+            "all-extras",
+            None,
+            "Install all available extra sets of dependencies, overriding --extras",
+        ),
+        option(
             "develop",
             None,
             "Install given packages in development mode.",
@@ -55,12 +60,19 @@ exist it will look for <comment>pyproject.toml</> and do the same.
             self.io, self.env, self.poetry.package, self.poetry.locker, self.poetry.pool
         )
 
-        extras = []
-        for extra in self.option("extras"):
-            if " " in extra:
-                extras += [e.strip() for e in extra.split(" ")]
-            else:
-                extras.append(extra)
+        if self.option("all-extras") and self.poetry.package.extras:
+            extras = [extra for extra in self.poetry.package.extras]
+
+            self.line("<info>Installing with all available extra dependencies.</info>")
+            self.line("Extras found: {}".format(", ".join(extras)))
+            self.line("")
+        else:
+            extras = []
+            for extra in self.option("extras"):
+                if " " in extra:
+                    extras += [e.strip() for e in extra.split(" ")]
+                else:
+                    extras.append(extra)
 
         installer.extras(extras)
         installer.dev_mode(not self.option("no-dev"))

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -1,0 +1,51 @@
+from cleo.testers import CommandTester
+
+from tests.helpers import get_package
+
+
+def test_install_all_extras(app_with_extras, repo, installer):
+    command = app_with_extras.find("install")
+    tester = CommandTester(command)
+
+    repo.add_package(get_package("pendulum", "1.4.4"))
+    repo.add_package(get_package("cachy", "0.2.0"))
+
+    tester.execute("--all-extras")
+
+    expected = """\
+Installing with all available extra dependencies.
+Extras found: extras_a, extras_b
+
+Updating dependencies
+Resolving dependencies...
+
+Writing lock file
+
+
+Package operations: 2 installs, 0 updates, 0 removals
+
+  - Installing cachy (0.2.0)
+  - Installing pendulum (1.4.4)
+  - Installing project-with-extras (1.2.3)
+"""
+
+    assert tester.io.fetch_output() == expected
+
+    assert len(installer.installs) == 2
+
+    content = app_with_extras.poetry.file.read()["tool"]["poetry"]
+
+    assert "cachy" in content["dependencies"]
+    assert content["dependencies"]["cachy"] == {"version": ">=0.2.0", "optional": True}
+
+    assert "pendulum" in content["dependencies"]
+    assert content["dependencies"]["pendulum"] == {
+        "version": ">=1.4.4",
+        "optional": True,
+    }
+
+    assert "extras_a" in content["extras"]
+    assert content["extras"]["extras_a"] == ["pendulum"]
+
+    assert "extras_b" in content["extras"]
+    assert content["extras"]["extras_b"] == ["cachy"]

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -185,6 +185,22 @@ def poetry(repo, project_directory):
 
 
 @pytest.fixture
+def poetry_with_extras(repo):
+    p = Poetry.create(Path(__file__).parent.parent / "fixtures" / "project_with_extras")
+
+    with p.file.path.open() as f:
+        content = f.read()
+
+    p.pool.remove_repository("pypi")
+    p.pool.add_repository(repo)
+
+    yield p
+
+    with p.file.path.open("w") as f:
+        f.write(content)
+
+
+@pytest.fixture
 def app(poetry):
     app_ = Application(poetry)
     app_.config.set_terminate_after_run(False)
@@ -193,5 +209,18 @@ def app(poetry):
 
 
 @pytest.fixture
+def app_with_extras(poetry_with_extras):
+    app_ = Application(poetry_with_extras)
+    app_.config.set_terminate_after_run(False)
+
+    return app_
+
+
+@pytest.fixture
 def app_tester(app):
     return ApplicationTester(app)
+
+
+@pytest.fixture
+def app_tester_with_extras(app_with_extras):
+    return ApplicationTester(app_with_extras)


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

----

* Removed broken anchor in CLI documentation page (`#extras`)
* Added `--all-extras` option to `install` command.


My use case to justify this addition:

We are using a big library with many extras not to bloat applications based on it with many dependencies (currently 10 extras, 1 new is getting merged and more will come). For users it's perfect, however when developing to run tests it's required to write out all of them and this needs to keep changing every time. Not only in console (copied from readme) but also in Dockerfile being used in tests, it's getting a bit too much.

When writing tests I wasn't too happy with copying over existing fixtures, but I didn't really know how to restructure them in a different way, everything else in `commands` is using `simple_project`. 