### PR TITLE
Add support for custom urls in metadata

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -251,6 +251,18 @@ To match the example in the setuptools documentation, you would use the followin
 ".rst" = "some_module:SomeClass"
 ```
 
+## `urls`
+
+In addition to the basic urls (`homepage`, `repository` and `documentation`), you can specify
+any custom url in the `urls` section.
+
+```toml
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/sdispater/poetry/issues"
+```
+
+If you publish you package on PyPI, they will appear in the `Project Links` section.
+
 ## Poetry and PEP-517
 
 [PEP-517](https://www.python.org/dev/peps/pep-0517/) introduces a standard way

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -161,6 +161,15 @@
                     }
                 }
             }
+        },
+        "urls": {
+            "type": "object",
+            "patternProperties": {
+                "^.+$": {
+                    "type": "string",
+                    "description": "The full url of the custom url."
+                }
+            }
         }
     },
     "definitions": {

--- a/poetry/packages/project_package.py
+++ b/poetry/packages/project_package.py
@@ -14,6 +14,7 @@ class ProjectPackage(Package):
         self.packages = []
         self.include = []
         self.exclude = []
+        self.custom_urls = {}
 
         if self._python_versions == "*":
             self._python_constraint = parse_constraint("~2.7 || >=3.4")
@@ -43,6 +44,14 @@ class ProjectPackage(Package):
         self._python_marker = parse_marker(
             create_nested_marker("python_version", self._python_constraint)
         )
+
+    @property
+    def urls(self):
+        urls = super(ProjectPackage, self).urls
+
+        urls.update(self.custom_urls)
+
+        return urls
 
     def clone(self):  # type: () -> ProjectPackage
         package = super(ProjectPackage, self).clone()

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -183,6 +183,10 @@ class Poetry:
         if "packages" in local_config:
             package.packages = local_config["packages"]
 
+        # Custom urls
+        if "urls" in local_config:
+            package.custom_urls = local_config["urls"]
+
         # Moving lock if necessary (pyproject.lock -> poetry.lock)
         lock = poetry_file.parent / "poetry.lock"
         if not lock.exists():

--- a/tests/masonry/builders/fixtures/complete/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete/pyproject.toml
@@ -42,3 +42,6 @@ time = ["pendulum"]
 my-script = "my_package:main"
 my-2nd-script = "my_package:main2"
 extra-script = {callable = "my_package.extra:main", extras = ["time"]}
+
+[tool.poetry.urls]
+"Issue Tracker" = "https://github.com/sdispater/poetry/issues"

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -103,6 +103,7 @@ def test_get_metadata_content():
     urls = parsed.get_all("Project-URL")
     assert urls == [
         "Documentation, https://poetry.eustace.io/docs",
+        "Issue Tracker, https://github.com/sdispater/poetry/issues",
         "Repository, https://github.com/sdispater/poetry",
     ]
 

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -221,6 +221,7 @@ Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
 Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
 Project-URL: Documentation, https://poetry.eustace.io/docs
+Project-URL: Issue Tracker, https://github.com/sdispater/poetry/issues
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst
 
@@ -320,6 +321,7 @@ Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
 Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
 Project-URL: Documentation, https://poetry.eustace.io/docs
+Project-URL: Issue Tracker, https://github.com/sdispater/poetry/issues
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst
 

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -99,6 +99,7 @@ Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
 Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
 Project-URL: Documentation, https://poetry.eustace.io/docs
+Project-URL: Issue Tracker, https://github.com/sdispater/poetry/issues
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst
 


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This PR introduces support for custom urls, which are part of the Core metadata specifications: https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use

A new `urls` section is now supported for this specific use case:

```toml
[tool.poetry.urls]
"Bug Tracker" = "https://github.com/sdispater/poetry/issues"
```
