### PR TITLE
Add full environment markers support 

### DIFF
--- a/docs/docs/versions.md
+++ b/docs/docs/versions.md
@@ -129,6 +129,17 @@ pathlib2 = { version = "^2.2", python = "~2.7" }
 pathlib2 = { version = "^2.2", python = ["~2.7", "^3.2"] }
 ```
 
+### Using environment markers
+
+If you need more complex install conditions for your dependencies,
+Poetry supports [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers)
+via the `markers` property:
+
+```toml
+[tool.poetry.dependencies]
+pathlib2 = { version = "^2.2", markers = "python_version ~= '2.7' or sys_platform == 'win32'" }
+```
+
 
 ### Multiple constraints dependencies
 

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -221,6 +221,10 @@
                     "type": "string",
                     "description": "The platform(s) for which the dependency should be installed."
                 },
+                "markers": {
+                    "type": "string",
+                    "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+                },
                 "allows-prereleases": {
                     "type": "boolean",
                     "description": "Whether the dependency allows prereleases or not."
@@ -274,6 +278,10 @@
                     "type": "string",
                     "description": "The platform(s) for which the dependency should be installed."
                 },
+                "markers": {
+                    "type": "string",
+                    "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+                },
                 "allows-prereleases": {
                     "type": "boolean",
                     "description": "Whether the dependency allows prereleases or not."
@@ -310,6 +318,10 @@
                     "type": "string",
                     "description": "The platform(s) for which the dependency should be installed."
                 },
+                "markers": {
+                    "type": "string",
+                    "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+                },
                 "optional": {
                     "type": "boolean",
                     "description": "Whether the dependency is optional or not."
@@ -341,6 +353,10 @@
                 "platform": {
                     "type": "string",
                     "description": "The platform(s) for which the dependency should be installed."
+                },
+                "markers": {
+                    "type": "string",
+                    "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
                 },
                 "optional": {
                     "type": "boolean",

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -245,6 +245,7 @@ class Package(object):
             optional = constraint.get("optional", False)
             python_versions = constraint.get("python")
             platform = constraint.get("platform")
+            markers = constraint.get("markers")
             allows_prereleases = constraint.get("allows-prereleases", False)
 
             if "git" in constraint:
@@ -301,25 +302,28 @@ class Package(object):
                     source_name=constraint.get("source"),
                 )
 
-            marker = AnyMarker()
-            if python_versions:
-                dependency.python_versions = python_versions
-                marker = marker.intersect(
-                    parse_marker(
-                        create_nested_marker(
-                            "python_version", dependency.python_constraint
+            if not markers:
+                marker = AnyMarker()
+                if python_versions:
+                    dependency.python_versions = python_versions
+                    marker = marker.intersect(
+                        parse_marker(
+                            create_nested_marker(
+                                "python_version", dependency.python_constraint
+                            )
                         )
                     )
-                )
 
-            if platform:
-                marker = marker.intersect(
-                    parse_marker(
-                        create_nested_marker(
-                            "sys_platform", parse_generic_constraint(platform)
+                if platform:
+                    marker = marker.intersect(
+                        parse_marker(
+                            create_nested_marker(
+                                "sys_platform", parse_generic_constraint(platform)
+                            )
                         )
                     )
-                )
+            else:
+                marker = parse_marker(markers)
 
             if not marker.is_any():
                 dependency.marker = marker

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -39,6 +39,9 @@ my-package = { path = "../project_with_setup/" }
 # Dir dependency with pyproject.toml
 simple-project = { path = "../simple_project/" }
 
+# Dependency with markers
+functools32 = { version = "^3.2.3", markers = "python_version ~= '2.7' and sys_platform == 'win32' or python_version in '3.4 3.5'" }
+
 
 [tool.poetry.extras]
 db = [ "orator" ]

--- a/tests/masonry/builders/fixtures/complete/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete/pyproject.toml
@@ -30,7 +30,10 @@ python = "^3.6"
 cleo = "^0.6"
 cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
-pendulum = { version = "^1.4", optional = true }
+[tool.poetry.dependencies.pendulum]
+version = "^1.4"
+markers= 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
+optional = true
 
 [tool.poetry.dev-dependencies]
 pytest = "~3.4"

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -97,7 +97,7 @@ def test_get_metadata_content():
     assert requires == [
         "cachy[msgpack] (>=0.2.0,<0.3.0)",
         "cleo (>=0.6,<0.7)",
-        'pendulum (>=1.4,<2.0); extra == "time"',
+        'pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")',
     ]
 
     urls = parsed.get_all("Project-URL")

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -219,7 +219,7 @@ Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Provides-Extra: time
 Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
-Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
+Requires-Dist: pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")
 Project-URL: Documentation, https://poetry.eustace.io/docs
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst
@@ -318,7 +318,7 @@ Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Provides-Extra: time
 Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
-Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
+Requires-Dist: pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")
 Project-URL: Documentation, https://poetry.eustace.io/docs
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -133,7 +133,11 @@ def test_make_setup():
             "my-script = my_package:main",
         ]
     }
-    assert ns["extras_require"] == {"time": ["pendulum>=1.4,<2.0"]}
+    assert ns["extras_require"] == {
+        'time:python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"': [
+            "pendulum>=1.4,<2.0"
+        ]
+    }
 
 
 def test_make_pkg_info(mocker):

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -97,7 +97,7 @@ Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Provides-Extra: time
 Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
-Requires-Dist: pendulum (>=1.4,<2.0); extra == "time"
+Requires-Dist: pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")
 Project-URL: Documentation, https://poetry.eustace.io/docs
 Project-URL: Repository, https://github.com/sdispater/poetry
 Description-Content-Type: text/x-rst

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -82,6 +82,14 @@ def test_poetry():
     assert simple_project.name == "simple-project"
     assert simple_project.pretty_constraint == "*"
 
+    functools32 = dependencies["functools32"]
+    assert functools32.name == "functools32"
+    assert functools32.pretty_constraint == "^3.2.3"
+    assert (
+        str(functools32.marker)
+        == 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
+    )
+
     assert "db" in package.extras
 
     classifiers = package.classifiers


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Up until now, Poetry only supported the `python` and `platform` properties to specify conditional dependencies. This PR adds support for any [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers) via the `markers` property.

```toml
[tool.poetry.dependencies]
pathlib2 = { version = "^2.2", markers = "python_version ~= '2.7' or sys_platform == 'win32'" }
```
