### PR TITLE
Typing syntax fixes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+check_untyped_defs = True
+ignore_errors = False
+ignore_missing_imports = True
+strict_optional = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True

--- a/poetry/config.py
+++ b/poetry/config.py
@@ -33,7 +33,11 @@ class Config:
     def content(self):
         return self._content
 
-    def setting(self, setting_name, default=None):  # type: (str) -> Any
+    def setting(
+        self,
+        setting_name,  # type: str
+        default=None,
+    ):
         """
         Retrieve a setting value.
         """

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -181,8 +181,8 @@ The <info>init</info> command creates a basic <comment>pyproject.toml</> file in
             f.write(content)
 
     def _determine_requirements(
-        self, requires, allow_prereleases=False  # type: List[str]  # type: bool
-    ):  # type: (...) -> List[str]
+        self, requires, allow_prereleases=False
+    ):  # type: (List[str], bool) -> List[str]
         if not requires:
             requires = []
 

--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -28,8 +28,11 @@ class ApplicationConfig(BaseApplicationConfig):
         self.add_event_listener(ConsoleEvents.PRE_HANDLE.value, self.set_env)
 
     def register_command_loggers(
-        self, event, event_name, _
-    ):  # type: (PreHandleEvent, str, ...) -> None
+        self,
+        event,  # type: PreHandleEvent
+        event_name,  # type: str
+        _,
+    ):  # type: (...) -> None
         command = event.command.config.handler
         if not isinstance(command, Command):
             return
@@ -56,7 +59,7 @@ class ApplicationConfig(BaseApplicationConfig):
 
             logger.setLevel(level)
 
-    def set_env(self, event, event_name, _):  # type: (PreHandleEvent, str, ...) -> None
+    def set_env(self, event, event_name, _):  # type: (PreHandleEvent, str, _) -> None
         from poetry.semver import parse_constraint
         from poetry.utils.env import EnvManager
 

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -22,7 +22,12 @@ from .base_installer import BaseInstaller
 
 
 class PipInstaller(BaseInstaller):
-    def __init__(self, env, io, pool):  # type: (Env, ...) -> None
+    def __init__(
+        self,
+        env,  # type: Env
+        io,
+        pool,
+    ):  # type: (...) -> None
         self._env = env
         self._io = io
         self._pool = pool

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -227,7 +227,7 @@ class Builder(object):
         return dict(result)
 
     @classmethod
-    def convert_author(cls, author):  # type: () -> dict
+    def convert_author(cls, author):  # type: (...) -> dict
         m = AUTHOR_REGEX.match(author)
 
         name = m.group("name")

--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -263,7 +263,9 @@ class SdistBuilder(Builder):
 
     @classmethod
     def convert_dependencies(
-        cls, package, dependencies  # type: Package  # type: List[Dependency]
+        cls,
+        package,  # type: Package
+        dependencies,  # type: List[Dependency]
     ):
         main = []
         extras = defaultdict(list)

--- a/poetry/masonry/utils/package_include.py
+++ b/poetry/masonry/utils/package_include.py
@@ -26,7 +26,7 @@ class PackageInclude(Include):
     def is_package(self):  # type: () -> bool
         return self._is_package
 
-    def is_module(self):  # type: ()
+    def is_module(self):  # type: () -> bool
         return self._is_module
 
     def refresh(self):  # type: () -> PackageInclude

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -134,7 +134,7 @@ class Locker(object):
 
         return packages
 
-    def set_lock_data(self, root, packages):  # type: () -> bool
+    def set_lock_data(self, root, packages):  # type: (...) -> bool
         hashes = {}
         packages = self._lock_packages(packages)
         # Retrieving hashes

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -55,7 +55,12 @@ class Provider:
 
     UNSAFE_PACKAGES = {"setuptools", "distribute", "pip"}
 
-    def __init__(self, package, pool, io):  # type: (Package, Pool, ...) -> None
+    def __init__(
+        self,
+        package,  # type: Package
+        pool,  # type: Pool
+        io,
+    ):  # type: (...) -> None
         self._package = package
         self._pool = pool
         self._io = io

--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -213,12 +213,13 @@ class Solver:
 
             marker = intersection
 
+        childrens = []  # type: List[Dict[str, Any]]
         graph = {
             "name": package.name,
             "category": category,
             "optional": optional,
             "marker": marker,
-            "children": [],  # type: List[Dict[str, Any]]
+            "children": childrens,
         }
 
         if previous_dep and previous_dep is not dep and previous_dep.name == dep.name:
@@ -257,7 +258,7 @@ class Solver:
                     # If there is already a child with this name
                     # we merge the requirements
                     existing = None
-                    for child in graph["children"]:
+                    for child in childrens:
                         if (
                             child["name"] == pkg.name
                             and child["category"] == dependency.category
@@ -278,7 +279,7 @@ class Solver:
                         )
                         continue
 
-                    graph["children"].append(child_graph)
+                    childrens.append(child_graph)
 
         return graph
 

--- a/poetry/semver/version.py
+++ b/poetry/semver/version.py
@@ -1,7 +1,7 @@
 import re
 
 from typing import List
-from typing import Union
+from typing import Optional
 
 from .empty_constraint import EmptyConstraint
 from .exceptions import ParseVersionError
@@ -19,14 +19,14 @@ class Version(VersionRange):
     def __init__(
         self,
         major,  # type: int
-        minor=None,  # type: Union[int, None]
-        patch=None,  # type: Union[int, None]
-        rest=None,  # type: Union[int, None]
-        pre=None,  # type: Union[str, None]
-        build=None,  # type: Union[str, None]
-        text=None,  # type: Union[str, None]
-        precision=None,  # type: Union[int, None]
-    ):  # type: () -> None
+        minor=None,  # type: Optional[int]
+        patch=None,  # type: Optional[int]
+        rest=None,  # type: Optional[int]
+        pre=None,  # type: Optional[str]
+        build=None,  # type: Optional[str]
+        text=None,  # type: Optional[str]
+        precision=None,  # type: Optional[int]
+    ):  # type: (...) -> None
         self._major = int(major)
         self._precision = None
         if precision is None:

--- a/poetry/version/__init__.py
+++ b/poetry/version/__init__.py
@@ -26,7 +26,8 @@ _trans_op = {
 
 
 def parse(
-    version, strict=False  # type: str  # type: bool
+    version,  # type: str
+    strict=False,  # type: bool
 ):  # type:(...) -> Union[Version, LegacyVersion]
     """
     Parse the given version string and return either a :class:`Version` object

--- a/poetry/version/utils.py
+++ b/poetry/version/utils.py
@@ -27,7 +27,7 @@ class Infinity(object):
         return NegativeInfinity
 
 
-Infinity = Infinity()
+Infinity = Infinity()  # type: ignore
 
 
 class NegativeInfinity(object):
@@ -59,4 +59,4 @@ class NegativeInfinity(object):
         return Infinity
 
 
-NegativeInfinity = NegativeInfinity()
+NegativeInfinity = NegativeInfinity()  # type: ignore


### PR DESCRIPTION
* Fix some function signatures that were messing with ellipsis
  for example, `fun(a, ...)` is not valid, but `fun(...)` is

* Dict value types - is that legal? ([puzzle/provider.py](https://github.com/sdispater/poetry/pull/1156/files#diff-d6fa69916de34b4fe357e0d6315bc805L221))

* Ignore assigning instance to classes
  (singletons like Infinity in [version/utils.py](https://github.com/sdispater/poetry/pull/1156/files#diff-1b900c3d89e0b0da23cc1bb84f446567L30))

# Pull Request Check List

- [ ] Added **tests** for changed code -- changed only type comments and introduced variable in provider.py; no new tests needed
- [ ] Updated **documentation** for changed code -- well, I can add some notes about mypy in contributing docs if all poetry team uses mypy every day as you use `black`.

I see that Poetry uses a lot of types. Maybe after fixing all typing errors (there is a lot of them right now) we could add mypy in the list of the pre-commit hooks?

P.S. Poetry has two almost identical CONTRIBUTING.md and docs/docs/contributing.md?
