### PR TITLE
check venv.create option before checking venv folder exists

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -183,17 +183,18 @@ class Env(object):
         in_venv = os.environ.get("VIRTUAL_ENV") is not None
 
         if not in_venv:
+            config = Config.create("config.toml")
+            # Check if we need to handle virtual env
+            create_venv = config.setting("settings.virtualenvs.create", True)
+
+            if not create_venv:
+                return SystemEnv(Path(sys.prefix))
+
             # Checking if a local virtualenv exists
             if (cwd / ".venv").exists():
                 venv = cwd / ".venv"
 
                 return VirtualEnv(venv)
-
-            config = Config.create("config.toml")
-            create_venv = config.setting("settings.virtualenvs.create", True)
-
-            if not create_venv:
-                return SystemEnv(Path(sys.prefix))
 
             venv_path = config.setting("settings.virtualenvs.path")
             if venv_path is None:


### PR DESCRIPTION
#696

# Pull Request Check List

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I struggled with weird behavior from #696 
I use poetry in a docker container and therefore use `settings.virtualenvs.create` option set in `False`.
But if a developer creates `.venv` folder and volumes project dir into container any poetry command fails with an exception.

I swapped `.venv` existence check with config `virtualenvs.create` check, but I not sure how to tests this. I added the test, and it doesn't work because of [this](https://github.com/sdispater/poetry/blob/master/poetry/utils/env.py#L192), poetry _creates_ new Config from a file, which hardcoded. And in the conftest, there is no option to define custom config and use it in another code. How can I handle this?
