### PR TITLE
Fix the build target at Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release: build linux_release osx_release
 
 build:
 	@poetry build
-	@python sonnet make:release
+	@python sonnet make release
 
 publish:
 	@poetry publish


### PR DESCRIPTION
Hello @sdispater,

This PR fixes the following situation:
```
$ make build
Building poetry (1.0.0a4)
 - Building sdist
 - Built poetry-1.0.0a4.tar.gz

 - Building wheel
 - Built poetry-1.0.0a4-py2.py3-none-any.whl

[CannotResolveCommandException]
The command "make:release" is not defined.
make: *** [Makefile:30: build] Error 1
```

Thank you for the amazing tool and the hard work you do!