### PR TITLE
Run command initialize() in order to ensure that directory structures are created

### DIFF
--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -78,7 +78,7 @@ To remove a repository (repo is a short alias for repositories):
 
         return unique_config_values
 
-    def initialize(self, i, o):
+    def initialize(self):
         from poetry.utils._compat import decode
 
         # Create config file if it does not exist
@@ -93,6 +93,9 @@ To remove a repository (repo is a short alias for repositories):
                 f.write(decode(AUTH_TEMPLATE))
 
     def handle(self):
+
+        self.initialize()
+
         if self.option("list"):
             self._list_configuration(self._settings_config.content)
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import tempfile
 
@@ -22,6 +23,16 @@ def setup(config):
     yield
 
     config.remove_property("settings.virtualenvs.path")
+
+
+@pytest.fixture()
+def nonexistent_config_path():
+    config_file_path = os.path.join(tempfile.gettempdir(), 'pypoetry', 'config.toml')
+    if os.path.exists(config_file_path):
+        os.unlink(config_file_path)
+    if os.path.exists(os.path.basename(config_file_path)):
+        os.rmdir(os.path.basename(config_file_path))
+    return config_file_path
 
 
 def test_list_displays_default_value_if_not_set(app, config):
@@ -69,4 +80,22 @@ def test_display_single_setting(app, config):
     expected = """true
 """
 
+    assert expected == tester.io.fetch_output()
+
+
+def test_autocreate_config_directory(app, nonexistent_config_path):
+    command = app.find("config")
+
+    command._settings_config = Config(TomlFile(nonexistent_config_path))
+
+    tester = CommandTester(command)
+    tester.execute("settings.virtualenvs.create false")
+
+    assert '' == tester.io.fetch_output()
+
+    tester = CommandTester(command)
+    tester.execute("settings.virtualenvs.create")
+
+    expected = """false
+"""
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -27,7 +27,7 @@ def setup(config):
 
 @pytest.fixture()
 def nonexistent_config_path():
-    config_file_path = os.path.join(tempfile.gettempdir(), 'pypoetry', 'config.toml')
+    config_file_path = os.path.join(tempfile.gettempdir(), "pypoetry", "config.toml")
     if os.path.exists(config_file_path):
         os.unlink(config_file_path)
     if os.path.exists(os.path.basename(config_file_path)):
@@ -91,7 +91,7 @@ def test_autocreate_config_directory(app, nonexistent_config_path):
     tester = CommandTester(command)
     tester.execute("settings.virtualenvs.create false")
 
-    assert '' == tester.io.fetch_output()
+    assert "" == tester.io.fetch_output()
 
     tester = CommandTester(command)
     tester.execute("settings.virtualenvs.create")


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] (N/A - bug) Updated **documentation** for changed code.

With the update the Cleo 0.7.x (https://github.com/sdispater/cleo/blob/master/CHANGELOG.md) the `initialize()` method of `ConfigCommand` was no longer being called by the superclass.  This PR just calls it explicitly from `handle()` in order to ensure that the directories are created.   Also adds a test to ensure that this functionality works correctly.
