### PR TITLE
Add rich file metadata to poetry.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - The `debug:resolve` command has been renamed to `debug resolve`.
 - The `self:update` command has been renamed to `self update`.
 - Changed the way virtualenvs are stored (names now depend on the project's path).
+- Added files metadata including hash. This deprecates metadata.hashes in `poetry.lock`.
 
 ### Fixed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,16 @@ optional = false
 python-versions = "*"
 version = "1.4.3"
 
+[[package.files]]
+hash = "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+name = "appdirs-1.4.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"
+name = "appdirs-1.4.3.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "A few extensions to pyyaml."
@@ -14,6 +24,16 @@ name = "aspy.yaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
+
+[[package.files]]
+hash = "463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc"
+name = "aspy.yaml-1.3.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
+name = "aspy.yaml-1.3.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 pyyaml = "*"
@@ -26,6 +46,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
 
+[[package.files]]
+hash = "03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"
+name = "atomicwrites-1.3.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+name = "atomicwrites-1.3.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Classes Without Boilerplate"
@@ -33,6 +63,16 @@ name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.1.0"
+
+[[package.files]]
+hash = "69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79"
+name = "attrs-19.1.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+name = "attrs-19.1.0.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface", "sphinx", "pre-commit"]
@@ -47,6 +87,16 @@ name = "black"
 optional = false
 python-versions = ">=3.6"
 version = "19.3b0"
+
+[[package.files]]
+hash = "09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf"
+name = "black-19.3b0-py36-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+name = "black-19.3b0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 appdirs = "*"
@@ -64,6 +114,11 @@ name = "cachecontrol"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.12.5"
+
+[[package.files]]
+hash = "cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7"
+name = "CacheControl-0.12.5.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 msgpack = "*"
@@ -85,6 +140,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.2.0"
 
+[[package.files]]
+hash = "b71e8e7ddb5b386e23e81befdfac8a93885406139b8681bedc17b3444fcb8fca"
+name = "cachy-0.2.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b71513e5a38ce90c1280c02b7d8d6bb3fdf64666c9cc0584f2479afea097d56c"
+name = "cachy-0.2.0.tar.gz"
+packagetype = "sdist"
+
 [package.extras]
 memcached = ["python-memcached (>=1.59.0.0,<2.0.0.0)"]
 msgpack = ["msgpack-python (>=0.5.0.0,<0.6.0.0)"]
@@ -96,7 +161,17 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.3.9"
+version = "2019.6.16"
+
+[[package.files]]
+hash = "046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939"
+name = "certifi-2019.6.16-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+name = "certifi-2019.6.16.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -105,6 +180,16 @@ name = "cfgv"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.0.0"
+
+[[package.files]]
+hash = "3bd31385cd2bebddbba8012200aaf15aa208539f1b33973759b4d02fc2148da5"
+name = "cfgv-2.0.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "32edbe09de6f4521224b87822103a8c16a614d31a894735f7a5b3bcf0eb3c37e"
+name = "cfgv-2.0.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 six = "*"
@@ -117,6 +202,16 @@ optional = false
 python-versions = "*"
 version = "3.0.4"
 
+[[package.files]]
+hash = "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+name = "chardet-3.0.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+name = "chardet-3.0.4.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Cleo allows you to create beautiful and testable command-line interfaces."
@@ -124,6 +219,16 @@ name = "cleo"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.7.4"
+
+[[package.files]]
+hash = "9b7d706309412e43d00723ed3074a300cd7879a0c685f4fef0b5052d7f4ab71f"
+name = "cleo-0.7.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "58d26642fa608a1515093275cd98875100c7d50f01fc1f3bbb7a78dbb73e4b14"
+name = "cleo-0.7.4.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 clikit = ">=0.2.4,<0.3.0"
@@ -139,6 +244,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "7.0"
 
+[[package.files]]
+hash = "2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"
+name = "Click-7.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+name = "Click-7.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "CliKit is a group of utilities to build beautiful and testable command line interfaces."
@@ -146,6 +261,16 @@ name = "clikit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.2.4"
+
+[[package.files]]
+hash = "a7597999555aeb2ce9946f07187f690ab6864213f337e51250178c4bd19bd810"
+name = "clikit-0.2.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d6807cf4a41e6b981b056075c0aefca2db1dabc597ed18fa4d92b8b2e2678835"
+name = "clikit-0.2.4.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 pastel = ">=0.1.0,<0.2.0"
@@ -168,6 +293,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.4.1"
 
+[[package.files]]
+hash = "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+name = "colorama-0.4.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"
+name = "colorama-0.4.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Updated configparser from Python 3.7 for Python 2.6+."
@@ -176,6 +311,16 @@ name = "configparser"
 optional = false
 python-versions = ">=2.6"
 version = "3.7.4"
+
+[[package.files]]
+hash = "8be81d89d6e7b4c0d4e44bcc525845f6da25821de80cb5e06e7e0238a2899e32"
+name = "configparser-3.7.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "da60d0014fd8c55eb48c1c5354352e363e2d30bbf7057e5e171a468390184c75"
+name = "configparser-3.7.4.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -190,6 +335,16 @@ optional = false
 python-versions = "*"
 version = "0.5.5"
 
+[[package.files]]
+hash = "f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00"
+name = "contextlib2-0.5.5-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48"
+name = "contextlib2-0.5.5.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Code coverage measurement for Python"
@@ -197,6 +352,211 @@ name = "coverage"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 version = "4.5.3"
+
+[[package.files]]
+hash = "a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b"
+name = "coverage-4.5.3-cp26-cp26m-macosx_10_12_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260"
+name = "coverage-4.5.3-cp27-cp27m-macosx_10_12_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd"
+name = "coverage-4.5.3-cp27-cp27m-macosx_10_13_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d"
+name = "coverage-4.5.3-cp27-cp27m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8"
+name = "coverage-4.5.3-cp27-cp27m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49"
+name = "coverage-4.5.3-cp27-cp27m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9"
+name = "coverage-4.5.3-cp27-cp27m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420"
+name = "coverage-4.5.3-cp27-cp27mu-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773"
+name = "coverage-4.5.3-cp27-cp27mu-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723"
+name = "coverage-4.5.3-cp33-cp33m-macosx_10_10_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034"
+name = "coverage-4.5.3-cp34-cp34m-macosx_10_12_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1"
+name = "coverage-4.5.3-cp34-cp34m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c"
+name = "coverage-4.5.3-cp34-cp34m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf"
+name = "coverage-4.5.3-cp34-cp34m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce"
+name = "coverage-4.5.3-cp34-cp34m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+name = "coverage-4.5.3-cp35-cp35m-macosx_10_12_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c"
+name = "coverage-4.5.3-cp35-cp35m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f"
+name = "coverage-4.5.3-cp35-cp35m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e"
+name = "coverage-4.5.3-cp35-cp35m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741"
+name = "coverage-4.5.3-cp35-cp35m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2"
+name = "coverage-4.5.3-cp36-cp36m-macosx_10_13_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe"
+name = "coverage-4.5.3-cp36-cp36m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e"
+name = "coverage-4.5.3-cp36-cp36m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4"
+name = "coverage-4.5.3-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74"
+name = "coverage-4.5.3-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab"
+name = "coverage-4.5.3-cp37-cp37m-macosx_10_13_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390"
+name = "coverage-4.5.3-cp37-cp37m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09"
+name = "coverage-4.5.3-cp37-cp37m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba"
+name = "coverage-4.5.3-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9"
+name = "coverage-4.5.3-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609"
+name = "coverage-4.5.3.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "4ec30ade438d1711562f3786bea33a9da6107414aed60a5daa974d50a8c2c351"
+name = "coverage-4.5.3.win-amd64-py2.7.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "93f965415cc51604f571e491f280cff0f5be35895b4eb5e55b47ae90c02a497b"
+name = "coverage-4.5.3.win-amd64-py3.4.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "ca58eba39c68010d7e87a823f22a081b5290e3e3c64714aac3c91481d8b34d22"
+name = "coverage-4.5.3.win-amd64-py3.5.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "6899797ac384b239ce1926f3cb86ffc19996f6fa3a1efbb23cb49e0c12d8c18c"
+name = "coverage-4.5.3.win-amd64-py3.6.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "8e679d1bde5e2de4a909efb071f14b472a678b788904440779d2c449c0355b27"
+name = "coverage-4.5.3.win-amd64-py3.7.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "42692db854d13c6c5e9541b6ffe0fe921fe16c9c446358d642ccae1462582d3b"
+name = "coverage-4.5.3.win32-py2.7.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "a9abc8c480e103dc05d9b332c6cc9fb1586330356fc14f1aa9c0ca5745097d19"
+name = "coverage-4.5.3.win32-py3.4.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "c22ab9f96cbaff05c6a84e20ec856383d27eae09e511d3e6ac4479489195861d"
+name = "coverage-4.5.3.win32-py3.5.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "2b412abc4c7d6e019ce7c27cbc229783035eef6d5401695dccba80f481be4eb3"
+name = "coverage-4.5.3.win32-py3.6.exe"
+packagetype = "bdist_wininst"
+
+[[package.files]]
+hash = "0c5fe441b9cfdab64719f24e9684502a59432df7570521563d7b1aff27ac755f"
+name = "coverage-4.5.3.win32-py3.7.exe"
+packagetype = "bdist_wininst"
 
 [[package]]
 category = "main"
@@ -207,6 +567,26 @@ optional = false
 python-versions = "*"
 version = "1.1.6"
 
+[[package.files]]
+hash = "6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79"
+name = "enum34-1.1.6-py2-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a"
+name = "enum34-1.1.6-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+name = "enum34-1.1.6.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
+name = "enum34-1.1.6.zip"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "A platform independent file lock."
@@ -214,6 +594,16 @@ name = "filelock"
 optional = false
 python-versions = "*"
 version = "3.0.12"
+
+[[package.files]]
+hash = "929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+name = "filelock-3.0.12-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
+name = "filelock-3.0.12.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -224,6 +614,16 @@ optional = false
 python-versions = "*"
 version = "1.0.2"
 
+[[package.files]]
+hash = "330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"
+name = "funcsigs-1.0.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+name = "funcsigs-1.0.2.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy."
@@ -232,6 +632,16 @@ name = "functools32"
 optional = false
 python-versions = "*"
 version = "3.2.3-2"
+
+[[package.files]]
+hash = "f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
+name = "functools32-3.2.3-2.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0"
+name = "functools32-3.2.3-2.zip"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -242,6 +652,16 @@ optional = false
 python-versions = ">=2.6, <3"
 version = "3.2.0"
 
+[[package.files]]
+hash = "ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+name = "futures-3.2.0-py2-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265"
+name = "futures-3.2.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Version of the glob module that can capture patterns and supports recursive wildcards"
@@ -251,6 +671,11 @@ optional = false
 python-versions = "*"
 version = "0.6"
 
+[[package.files]]
+hash = "f5b0a686ff21f820c4d3f0c4edd216704cea59d79d00fa337e244a2f2ff83ed6"
+name = "glob2-0.6.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "HTML parser based on the WHATWG HTML specification"
@@ -258,6 +683,16 @@ name = "html5lib"
 optional = false
 python-versions = "*"
 version = "1.0.1"
+
+[[package.files]]
+hash = "20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3"
+name = "html5lib-1.0.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"
+name = "html5lib-1.0.1.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 six = ">=1.9"
@@ -278,6 +713,11 @@ optional = false
 python-versions = "*"
 version = "0.9.6"
 
+[[package.files]]
+hash = "01b52d45077e702eda491f4fe75328d3468fd886aed5dcc530003e7b2b5939dc"
+name = "httpretty-0.9.6.tar.gz"
+packagetype = "sdist"
+
 [package.dependencies]
 six = "*"
 
@@ -287,7 +727,17 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.4"
+version = "1.4.5"
+
+[[package.files]]
+hash = "0a11379b46d06529795442742a043dc2fa14cd8c995ae81d1febbc5f1c014c87"
+name = "identify-1.4.5-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "43a5d24ffdb07bc7e21faf68b08e9f526a1f41f0056073f480291539ef961dfd"
+name = "identify-1.4.5.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 license = ["editdistance"]
@@ -300,20 +750,40 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.8"
 
+[[package.files]]
+hash = "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+name = "idna-2.8-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+name = "idna-2.8.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Read metadata from Python packages"
 name = "importlib-metadata"
 optional = false
 python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.17"
+version = "0.18"
+
+[[package.files]]
+hash = "6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7"
+name = "importlib_metadata-0.18-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+name = "importlib_metadata-0.18.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.dependencies.configparser]
 python = "<3"
-version = "*"
+version = ">=3.5"
 
 [package.dependencies.contextlib2]
 python = "<3"
@@ -330,6 +800,16 @@ name = "importlib-resources"
 optional = false
 python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
 version = "1.0.2"
+
+[[package.files]]
+hash = "6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b"
+name = "importlib_resources-1.0.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"
+name = "importlib_resources-1.0.2.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 [package.dependencies.pathlib2]
@@ -349,6 +829,16 @@ optional = false
 python-versions = "*"
 version = "2.10.1"
 
+[[package.files]]
+hash = "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+name = "Jinja2-2.10.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"
+name = "Jinja2-2.10.1.tar.gz"
+packagetype = "sdist"
+
 [package.dependencies]
 MarkupSafe = ">=0.23"
 
@@ -362,6 +852,16 @@ name = "jsonschema"
 optional = false
 python-versions = "*"
 version = "3.0.1"
+
+[[package.files]]
+hash = "a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"
+name = "jsonschema-3.0.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d"
+name = "jsonschema-3.0.1.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 attrs = ">=17.4.0"
@@ -385,6 +885,16 @@ optional = false
 python-versions = "*"
 version = "2.6.1"
 
+[[package.files]]
+hash = "78d55f2c268a8823ba499305dcac64e28ddeb9a92571e12d543cd304faf5817b"
+name = "livereload-2.6.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66"
+name = "livereload-2.6.1.tar.gz"
+packagetype = "sdist"
+
 [package.dependencies]
 six = "*"
 tornado = "*"
@@ -398,6 +908,16 @@ optional = false
 python-versions = "*"
 version = "0.12.2"
 
+[[package.files]]
+hash = "6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"
+name = "lockfile-0.12.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"
+name = "lockfile-0.12.2.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Python implementation of Markdown."
@@ -406,6 +926,16 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "3.0.1"
 
+[[package.files]]
+hash = "c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa"
+name = "Markdown-3.0.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
+name = "Markdown-3.0.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Python implementation of Markdown."
@@ -413,6 +943,16 @@ name = "markdown"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 version = "3.1.1"
+
+[[package.files]]
+hash = "56a46ac655704b91e5b7e6326ce43d5ef72411376588afa1dd90e881b83c7e8c"
+name = "Markdown-3.1.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a"
+name = "Markdown-3.1.1.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 setuptools = ">=36"
@@ -429,6 +969,146 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
 
+[[package.files]]
+hash = "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"
+name = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+name = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"
+name = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"
+name = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"
+name = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"
+name = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"
+name = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"
+name = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"
+name = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"
+name = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"
+name = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"
+name = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"
+name = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"
+name = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"
+name = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"
+name = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"
+name = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"
+name = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"
+name = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"
+name = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"
+name = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"
+name = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"
+name = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"
+name = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"
+name = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"
+name = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"
+name = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+name = "MarkupSafe-1.1.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Project documentation with Markdown."
@@ -437,6 +1117,16 @@ name = "mkdocs"
 optional = false
 python-versions = ">=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.0.4"
+
+[[package.files]]
+hash = "8cc8b38325456b9e942c981a209eaeb1e9f3f77b493ad755bfef889b9c8d356a"
+name = "mkdocs-1.0.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939"
+name = "mkdocs-1.0.4.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 Jinja2 = ">=2.7.1"
@@ -454,6 +1144,16 @@ name = "mock"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "3.0.5"
+
+[[package.files]]
+hash = "d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"
+name = "mock-3.0.5-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3"
+name = "mock-3.0.5.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 six = "*"
@@ -476,6 +1176,21 @@ optional = false
 python-versions = "*"
 version = "5.0.0"
 
+[[package.files]]
+hash = "38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4"
+name = "more-itertools-5.0.0.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc"
+name = "more_itertools-5.0.0-py2-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+name = "more_itertools-5.0.0-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
 [package.dependencies]
 six = ">=1.0.0,<2.0.0"
 
@@ -488,6 +1203,16 @@ optional = false
 python-versions = ">=3.4"
 version = "7.0.0"
 
+[[package.files]]
+hash = "c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+name = "more-itertools-7.0.0.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7"
+name = "more_itertools-7.0.0-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
 [[package]]
 category = "main"
 description = "MessagePack (de)serializer."
@@ -495,6 +1220,91 @@ name = "msgpack"
 optional = false
 python-versions = "*"
 version = "0.6.1"
+
+[[package.files]]
+hash = "3129c355342853007de4a2a86e75eab966119733eb15748819b6554363d4e85c"
+name = "msgpack-0.6.1-cp27-cp27m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "31f6d645ee5a97d59d3263fab9e6be76f69fa131cddc0d94091a3c8aca30d67a"
+name = "msgpack-0.6.1-cp27-cp27m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "fd509d4aa95404ce8d86b4e32ce66d5d706fd6646c205e1c2a715d87078683a2"
+name = "msgpack-0.6.1-cp27-cp27m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "70cebfe08fb32f83051971264466eadf183101e335d8107b80002e632f425511"
+name = "msgpack-0.6.1-cp27-cp27m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8e68c76c6aff4849089962d25346d6784d38e02baa23ffa513cf46be72e3a540"
+name = "msgpack-0.6.1-cp27-cp27mu-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "86b963a5de11336ec26bc4f839327673c9796b398b9f1fe6bb6150c2a5d00f0f"
+name = "msgpack-0.6.1-cp27-cp27mu-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "72cb7cf85e9df5251abd7b61a1af1fb77add15f40fa7328e924a9c0b6bc7a533"
+name = "msgpack-0.6.1-cp35-cp35m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8c73c9bcdfb526247c5e4f4f6cf581b9bb86b388df82cfcaffde0a6e7bf3b43a"
+name = "msgpack-0.6.1-cp35-cp35m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "26cb40116111c232bc235ce131cc3b4e76549088cb154e66a2eb8ff6fcc907ec"
+name = "msgpack-0.6.1-cp36-cp36m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "62bd8e43d204580308d477a157b78d3fee2fb4c15d32578108dc5d89866036c8"
+name = "msgpack-0.6.1-cp36-cp36m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a28e69fe5468c9f5251c7e4e7232286d71b7dfadc74f312006ebe984433e9746"
+name = "msgpack-0.6.1-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "97ac6b867a8f63debc64f44efdc695109d541ecc361ee2dce2c8884ab37360a1"
+name = "msgpack-0.6.1-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "3ce7ef7ee2546c3903ca8c934d09250531b80c6127e6478781ae31ed835aac4c"
+name = "msgpack-0.6.1-cp37-cp37m-manylinux1_i686.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7c55649965c35eb32c499d17dadfb8f53358b961582846e1bc06f66b9bccc556"
+name = "msgpack-0.6.1-cp37-cp37m-manylinux1_x86_64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "9d4f546af72aa001241d74a79caec278bcc007b4bcde4099994732e98012c858"
+name = "msgpack-0.6.1-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "300fd3f2c664a3bf473d6a952f843b4a71454f4c592ed7e74a36b205c1782d28"
+name = "msgpack-0.6.1-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "4008c72f5ef2b7936447dcb83db41d97e9791c83221be13d5e19db0796df1972"
+name = "msgpack-0.6.1.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -504,6 +1314,11 @@ optional = false
 python-versions = "*"
 version = "1.3.3"
 
+[[package.files]]
+hash = "ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a"
+name = "nodeenv-1.3.3.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Core utilities for Python packages"
@@ -511,6 +1326,16 @@ name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.0"
+
+[[package.files]]
+hash = "9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+name = "packaging-19.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af"
+name = "packaging-19.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -524,6 +1349,16 @@ optional = false
 python-versions = "*"
 version = "0.1.0"
 
+[[package.files]]
+hash = "d1fee8079534f99f1805a044fef946d23eee6d6a7cd34292c30e6c16be9a80b9"
+name = "pastel-0.1.0-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "3108af417ec0fa6d0a620e676ec4f02c839ca13e10611586e5d2174b46aa0bc3"
+name = "pastel-0.1.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Object-oriented filesystem paths"
@@ -532,6 +1367,16 @@ name = "pathlib2"
 optional = false
 python-versions = "*"
 version = "2.3.3"
+
+[[package.files]]
+hash = "5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+name = "pathlib2-2.3.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742"
+name = "pathlib2-2.3.3.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 six = "*"
@@ -548,6 +1393,16 @@ optional = false
 python-versions = "*"
 version = "1.5.0.1"
 
+[[package.files]]
+hash = "a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"
+name = "pkginfo-1.5.0.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb"
+name = "pkginfo-1.5.0.1.tar.gz"
+packagetype = "sdist"
+
 [package.extras]
 testing = ["nose", "coverage"]
 
@@ -558,6 +1413,16 @@ name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.12.0"
+
+[[package.files]]
+hash = "b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+name = "pluggy-0.12.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc"
+name = "pluggy-0.12.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 importlib-metadata = ">=0.12"
@@ -572,6 +1437,16 @@ name = "pre-commit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.17.0"
+
+[[package.files]]
+hash = "92e406d556190503630fd801958379861c94884693a032ba66629d0351fdccd4"
+name = "pre_commit-1.17.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "cccc39051bc2457b0c0f7152a411f8e05e3ba2fe1a5613e4ee0833c1c1985ce3"
+name = "pre_commit-1.17.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 "aspy.yaml" = "*"
@@ -600,6 +1475,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.0"
 
+[[package.files]]
+hash = "64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"
+name = "py-1.8.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+name = "py-1.8.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -607,6 +1492,16 @@ name = "pygments"
 optional = false
 python-versions = "*"
 version = "2.3.1"
+
+[[package.files]]
+hash = "e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+name = "Pygments-2.3.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a"
+name = "Pygments-2.3.1.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -616,6 +1511,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.4.2"
 
+[[package.files]]
+hash = "71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127"
+name = "Pygments-2.4.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+name = "Pygments-2.4.2.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Pygments Github custom lexers."
@@ -623,6 +1528,16 @@ name = "pygments-github-lexers"
 optional = false
 python-versions = "*"
 version = "0.0.5"
+
+[[package.files]]
+hash = "aaca57e77cd6fcfce8d6ee97a998962eebf7fbb810519a8ebde427c62823e133"
+name = "pygments-github-lexers-0.0.5.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "0f9e9fb607d351c127a1e55e82a6eb491ed1fc11b2d6a0444ba217dc6d1f82c1"
+name = "pygments_github_lexers-0.0.5-py3.4.egg"
+packagetype = "bdist_egg"
 
 [package.dependencies]
 pygments = ">=2.0.2"
@@ -635,6 +1550,16 @@ optional = false
 python-versions = "*"
 version = "1.3.0"
 
+[[package.files]]
+hash = "1d29a87beb45ebe1e821e7a3b10da2b6b2f4c79b43f482c2df1a1f748a6e114e"
+name = "pylev-1.3.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "063910098161199b81e453025653ec53556c1be7165a9b7c50be2f4d57eae1c3"
+name = "pylev-1.3.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Extension pack for Python Markdown."
@@ -642,6 +1567,16 @@ name = "pymdown-extensions"
 optional = false
 python-versions = "*"
 version = "6.0"
+
+[[package.files]]
+hash = "6cf0cf36b5a03b291ace22dc2f320f4789ce56fbdb6635a3be5fadbf5d7694dd"
+name = "pymdown-extensions-6.0.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "25b0a7967fa697b5035e23340a48594e3e93acb10b06d74574218ace3347d1df"
+name = "pymdown_extensions-6.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
 
 [package.dependencies]
 Markdown = ">=3.0.1"
@@ -654,6 +1589,16 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.0"
 
+[[package.files]]
+hash = "9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+name = "pyparsing-2.4.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a"
+name = "pyparsing-2.4.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Persistent/Functional/Immutable data structures"
@@ -661,6 +1606,11 @@ name = "pyrsistent"
 optional = false
 python-versions = "*"
 version = "0.14.11"
+
+[[package.files]]
+hash = "3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"
+name = "pyrsistent-0.14.11.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 six = "*"
@@ -672,6 +1622,16 @@ name = "pytest"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "4.6.3"
+
+[[package.files]]
+hash = "926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
+name = "pytest-4.6.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45"
+name = "pytest-4.6.3.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -711,6 +1671,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.7.1"
 
+[[package.files]]
+hash = "e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
+name = "pytest-cov-2.7.1.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6"
+name = "pytest_cov-2.7.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
@@ -725,6 +1695,16 @@ name = "pytest-mock"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.10.4"
+
+[[package.files]]
+hash = "5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"
+name = "pytest-mock-1.10.4.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7"
+name = "pytest_mock-1.10.4-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -744,6 +1724,16 @@ optional = false
 python-versions = "*"
 version = "0.9.2"
 
+[[package.files]]
+hash = "fcd87a74b2bce5386d244b49ad60549bfbc4602527797fac167da147983f58ab"
+name = "pytest-sugar-0.9.2.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "26cf8289fe10880cbbc130bd77398c4e6a8b936d8393b116a5c16121d95ab283"
+name = "pytest_sugar-0.9.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
 [package.dependencies]
 packaging = ">=14.1"
 pytest = ">=2.9"
@@ -757,6 +1747,61 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "5.1.1"
 
+[[package.files]]
+hash = "70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265"
+name = "PyYAML-5.1.1-cp27-cp27m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778"
+name = "PyYAML-5.1.1-cp27-cp27m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e"
+name = "PyYAML-5.1.1-cp34-cp34m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3"
+name = "PyYAML-5.1.1-cp34-cp34m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190"
+name = "PyYAML-5.1.1-cp35-cp35m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+name = "PyYAML-5.1.1-cp35-cp35m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7"
+name = "PyYAML-5.1.1-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043"
+name = "PyYAML-5.1.1-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225"
+name = "PyYAML-5.1.1-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391"
+name = "PyYAML-5.1.1-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955"
+name = "PyYAML-5.1.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Python HTTP for Humans."
@@ -764,6 +1809,16 @@ name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.21.0"
+
+[[package.files]]
+hash = "7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+name = "requests-2.21.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e"
+name = "requests-2.21.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -783,6 +1838,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.22.0"
 
+[[package.files]]
+hash = "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+name = "requests-2.22.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
+name = "requests-2.22.0.tar.gz"
+packagetype = "sdist"
+
 [package.dependencies]
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<3.1.0"
@@ -801,6 +1866,16 @@ optional = false
 python-versions = "*"
 version = "0.8.0"
 
+[[package.files]]
+hash = "f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
+name = "requests-toolbelt-0.8.0.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237"
+name = "requests_toolbelt-0.8.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
 
@@ -813,6 +1888,61 @@ optional = false
 python-versions = "*"
 version = "1.10.0"
 
+[[package.files]]
+hash = "92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"
+name = "scandir-1.10.0-cp27-cp27m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+name = "scandir-1.10.0-cp27-cp27m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"
+name = "scandir-1.10.0-cp34-cp34m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"
+name = "scandir-1.10.0-cp34-cp34m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"
+name = "scandir-1.10.0-cp35-cp35m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"
+name = "scandir-1.10.0-cp35-cp35m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"
+name = "scandir-1.10.0-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"
+name = "scandir-1.10.0-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"
+name = "scandir-1.10.0-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"
+name = "scandir-1.10.0-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"
+name = "scandir-1.10.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Tool to Detect Surrounding Shell"
@@ -820,6 +1950,16 @@ name = "shellingham"
 optional = false
 python-versions = ">=2.6,!=3.0,!=3.1,!=3.2,!=3.3"
 version = "1.3.1"
+
+[[package.files]]
+hash = "77d37a4fd287c1e663006f7ecf1b9deca9ad492d0082587bd813c44eb49e4e62"
+name = "shellingham-1.3.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "985b23bbd1feae47ca6a6365eacd314d93d95a8a16f8f346945074c28fe6f3e0"
+name = "shellingham-1.3.1.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "main"
@@ -829,6 +1969,16 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 version = "1.12.0"
 
+[[package.files]]
+hash = "3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c"
+name = "six-1.12.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+name = "six-1.12.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "ANSII Color formatting for output in terminal."
@@ -836,6 +1986,11 @@ name = "termcolor"
 optional = false
 python-versions = "*"
 version = "1.1.0"
+
+[[package.files]]
+hash = "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+name = "termcolor-1.1.0.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "dev"
@@ -845,6 +2000,21 @@ optional = false
 python-versions = "*"
 version = "0.10.0"
 
+[[package.files]]
+hash = "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"
+name = "toml-0.10.0-py2.7.egg"
+packagetype = "bdist_egg"
+
+[[package.files]]
+hash = "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+name = "toml-0.10.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"
+name = "toml-0.10.0.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Style preserving TOML library"
@@ -852,6 +2022,16 @@ name = "tomlkit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.5.3"
+
+[[package.files]]
+hash = "f077456d35303e7908cc233b340f71e0bec96f63429997f38ca9272b7d64029e"
+name = "tomlkit-0.5.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d6506342615d051bc961f70bfcfa3d29b6616cc08a3ddfd4bc24196f16fd4ec2"
+name = "tomlkit-0.5.3.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 [package.dependencies.enum34]
@@ -875,6 +2055,41 @@ optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, != 3.3.*"
 version = "5.1.1"
 
+[[package.files]]
+hash = "732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f"
+name = "tornado-5.1.1-cp35-cp35m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d"
+name = "tornado-5.1.1-cp35-cp35m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f"
+name = "tornado-5.1.1-cp36-cp36m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb"
+name = "tornado-5.1.1-cp36-cp36m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
+name = "tornado-5.1.1-cp37-cp37m-win32.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5"
+name = "tornado-5.1.1-cp37-cp37m-win_amd64.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409"
+name = "tornado-5.1.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "tox is a generic virtualenv management and test command line tool"
@@ -882,6 +2097,16 @@ name = "tox"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "3.12.1"
+
+[[package.files]]
+hash = "f5c8e446b51edd2ea97df31d4ded8c8b72e7d6c619519da6bb6084b9dd5770f9"
+name = "tox-3.12.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f"
+name = "tox-3.12.1.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
 filelock = ">=3.0.0,<4"
@@ -903,7 +2128,22 @@ marker = "python_version >= \"2.7\" and python_version < \"2.8\" or python_versi
 name = "typing"
 optional = false
 python-versions = "*"
-version = "3.6.6"
+version = "3.7.4"
+
+[[package.files]]
+hash = "38566c558a0a94d6531012c8e917b1b8518a41e418f7f15f00e129cc80162ad3"
+name = "typing-3.7.4-py2-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "84698954b4e6719e912ef9a42a2431407fe3755590831699debda6fba92aac55"
+name = "typing-3.7.4-py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "53765ec4f83a2b720214727e319607879fec4acde22c4fbb54fa2604e79e44ce"
+name = "typing-3.7.4.tar.gz"
+packagetype = "sdist"
 
 [[package]]
 category = "main"
@@ -912,6 +2152,16 @@ name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.24.3"
+
+[[package.files]]
+hash = "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+name = "urllib3-1.24.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4"
+name = "urllib3-1.24.3.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
@@ -925,6 +2175,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.25.3"
 
+[[package.files]]
+hash = "b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1"
+name = "urllib3-1.25.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+name = "urllib3-1.25.3.tar.gz"
+packagetype = "sdist"
+
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
@@ -936,7 +2196,17 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "16.6.0"
+version = "16.6.1"
+
+[[package.files]]
+hash = "d28ca64c0f3f125f59cabf13e0a150e1c68e5eea60983cc4395d88c584495783"
+name = "virtualenv-16.6.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b7335cddd9260a3dd214b73a2521ffc09647bde3e9457fcca31dc3be3999d04a"
+name = "virtualenv-16.6.1.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
@@ -950,6 +2220,16 @@ optional = false
 python-versions = "*"
 version = "0.1.7"
 
+[[package.files]]
+hash = "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+name = "wcwidth-0.1.7-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"
+name = "wcwidth-0.1.7.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "main"
 description = "Character encoding aliases for legacy web content"
@@ -958,6 +2238,16 @@ optional = false
 python-versions = "*"
 version = "0.5.1"
 
+[[package.files]]
+hash = "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"
+name = "webencodings-0.5.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+name = "webencodings-0.5.1.tar.gz"
+packagetype = "sdist"
+
 [[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -965,6 +2255,16 @@ name = "zipp"
 optional = false
 python-versions = ">=2.7"
 version = "0.5.1"
+
+[[package.files]]
+hash = "8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d"
+name = "zipp-0.5.1-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+name = "zipp-0.5.1.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -982,7 +2282,7 @@ attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0
 black = ["09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf", "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"]
 cachecontrol = ["cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7"]
 cachy = ["b71513e5a38ce90c1280c02b7d8d6bb3fdf64666c9cc0584f2479afea097d56c", "b71e8e7ddb5b386e23e81befdfac8a93885406139b8681bedc17b3444fcb8fca"]
-certifi = ["59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5", "b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"]
+certifi = ["046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939", "945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"]
 cfgv = ["32edbe09de6f4521224b87822103a8c16a614d31a894735f7a5b3bcf0eb3c37e", "3bd31385cd2bebddbba8012200aaf15aa208539f1b33973759b4d02fc2148da5"]
 chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
 cleo = ["58d26642fa608a1515093275cd98875100c7d50f01fc1f3bbb7a78dbb73e4b14", "9b7d706309412e43d00723ed3074a300cd7879a0c685f4fef0b5052d7f4ab71f"]
@@ -1000,9 +2300,9 @@ futures = ["9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265", "
 glob2 = ["f5b0a686ff21f820c4d3f0c4edd216704cea59d79d00fa337e244a2f2ff83ed6"]
 html5lib = ["20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3", "66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"]
 httpretty = ["01b52d45077e702eda491f4fe75328d3468fd886aed5dcc530003e7b2b5939dc"]
-identify = ["3e8268640da8fa2a62acd5af2c299c45597a9a845d6706b3c19ddd5a46fb32dd", "78fcb1bdd37f4ecc954e8cba01680054781412a8aac82aed1998d8b5c8488011"]
+identify = ["0a11379b46d06529795442742a043dc2fa14cd8c995ae81d1febbc5f1c014c87", "43a5d24ffdb07bc7e21faf68b08e9f526a1f41f0056073f480291539ef961dfd"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
-importlib-metadata = ["a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f", "df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"]
+importlib-metadata = ["6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7", "cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"]
 importlib-resources = ["6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b", "d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"]
 jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
 jsonschema = ["0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d", "a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"]
@@ -1043,9 +2343,9 @@ toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235
 tomlkit = ["d6506342615d051bc961f70bfcfa3d29b6616cc08a3ddfd4bc24196f16fd4ec2", "f077456d35303e7908cc233b340f71e0bec96f63429997f38ca9272b7d64029e"]
 tornado = ["0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d", "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409", "732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f", "8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f", "8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5", "d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb", "e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"]
 tox = ["f5c8e446b51edd2ea97df31d4ded8c8b72e7d6c619519da6bb6084b9dd5770f9", "f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f"]
-typing = ["4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d", "57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4", "a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"]
+typing = ["38566c558a0a94d6531012c8e917b1b8518a41e418f7f15f00e129cc80162ad3", "53765ec4f83a2b720214727e319607879fec4acde22c4fbb54fa2604e79e44ce", "84698954b4e6719e912ef9a42a2431407fe3755590831699debda6fba92aac55"]
 urllib3 = ["2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4", "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb", "b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1", "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"]
-virtualenv = ["99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0", "fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"]
+virtualenv = ["b7335cddd9260a3dd214b73a2521ffc09647bde3e9457fcca31dc3be3999d04a", "d28ca64c0f3f125f59cabf13e0a150e1c68e5eea60983cc4395d88c584495783"]
 wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
 webencodings = ["a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"]
 zipp = ["8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d", "ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"]

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -108,7 +108,14 @@ class PipInstaller(BaseInstaller):
     def requirement(self, package, formatted=False):
         if formatted and not package.source_type:
             req = "{}=={}".format(package.name, package.version)
-            for h in package.hashes:
+
+            # metadata.hashes is still supported as a fallback method
+            # if files has not yet been created
+            hashes = package.hashes
+            if package.files:
+                hashes = (f["hash"] for f in package.files)
+
+            for h in hashes:
                 hash_type = "sha256"
                 if ":" in h:
                     hash_type, h = h.split(":")

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -244,6 +244,9 @@ class Locker(object):
             "python-versions": package.python_versions,
             "hashes": sorted(package.hashes),
         }
+        if package.files:
+            data["files"] = sorted(package.files, key=lambda f: f["name"])
+
         if not package.marker.is_any():
             data["marker"] = str(package.marker)
 

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -68,6 +68,8 @@ class Package(object):
         self.hashes = []
         self.optional = False
 
+        self.files = []
+
         self.classifiers = []
 
         self._python_versions = "*"

--- a/tests/installation/fixtures/with-file-dependency.test
+++ b/tests/installation/fixtures/with-file-dependency.test
@@ -1,15 +1,10 @@
 [[package]]
-name = "demo"
-version = "0.1.0"
-description = ""
 category = "main"
+description = ""
+name = "demo"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.source]
-type = "file"
-reference = ""
-url = "tests/fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl"
+version = "0.1.0"
 
 [package.dependencies]
 pendulum = ">=1.4.4"
@@ -18,17 +13,22 @@ pendulum = ">=1.4.4"
 bar = ["tomlkit"]
 foo = ["cleo"]
 
+[package.source]
+reference = ""
+type = "file"
+url = "tests/fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl"
+
 [[package]]
-name = "pendulum"
-version = "1.4.4"
-description = ""
 category = "main"
+description = ""
+name = "pendulum"
 optional = false
 python-versions = "*"
+version = "1.4.4"
 
 [metadata]
-python-versions = "*"
 content-hash = "123456789"
+python-versions = "*"
 
 [metadata.hashes]
 demo = ["70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a"]

--- a/tests/installation/fixtures/with-pypi-repository.test
+++ b/tests/installation/fixtures/with-pypi-repository.test
@@ -1,10 +1,20 @@
 [[package]]
-name = "attrs"
-version = "17.4.0"
-description = "Classes Without Boilerplate"
 category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
 optional = false
 python-versions = "*"
+version = "17.4.0"
+
+[[package.files]]
+hash = "a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+name = "attrs-17.4.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
+name = "attrs-17.4.0.tar.gz"
+packagetype = "sdist"
 
 [package.extras]
 dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface", "sphinx", "zope.interface"]
@@ -12,79 +22,152 @@ docs = ["sphinx", "zope.interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface"]
 
 [[package]]
-name = "colorama"
-version = "0.3.9"
+category = "dev"
 description = "Cross-platform colored terminal text."
-category = "dev"
 marker = "sys_platform == \"win32\""
+name = "colorama"
 optional = false
 python-versions = "*"
+version = "0.3.9"
+
+[[package.files]]
+hash = "463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda"
+name = "colorama-0.3.9-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+name = "colorama-0.3.9.tar.gz"
+packagetype = "sdist"
 
 [[package]]
-name = "funcsigs"
-version = "1.0.2"
+category = "dev"
 description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
-category = "dev"
 marker = "python_version < \"3.0\""
+name = "funcsigs"
 optional = false
 python-versions = "*"
+version = "1.0.2"
+
+[[package.files]]
+hash = "330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"
+name = "funcsigs-1.0.2-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+name = "funcsigs-1.0.2.tar.gz"
+packagetype = "sdist"
 
 [[package]]
-name = "more-itertools"
-version = "4.1.0"
-description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
 optional = false
 python-versions = "*"
+version = "4.1.0"
+
+[[package.files]]
+hash = "c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+name = "more-itertools-4.1.0.tar.gz"
+packagetype = "sdist"
+
+[[package.files]]
+hash = "11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e"
+name = "more_itertools-4.1.0-py2-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea"
+name = "more_itertools-4.1.0-py3-none-any.whl"
+packagetype = "bdist_wheel"
 
 [package.dependencies]
 six = ">=1.0.0,<2.0.0"
 
 [[package]]
-name = "pluggy"
-version = "0.6.0"
+category = "dev"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.6.0"
+
+[[package.files]]
+hash = "7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+name = "pluggy-0.6.0.tar.gz"
+packagetype = "sdist"
 
 [[package]]
-name = "py"
-version = "1.5.3"
+category = "dev"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5.3"
+
+[[package.files]]
+hash = "983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+name = "py-1.5.3-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881"
+name = "py-1.5.3.tar.gz"
+packagetype = "sdist"
 
 [[package]]
-name = "pytest"
-version = "3.5.0"
-description = "pytest: simple powerful testing with Python"
 category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.5.0"
+
+[[package.files]]
+hash = "6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c"
+name = "pytest-3.5.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+name = "pytest-3.5.0.tar.gz"
+packagetype = "sdist"
 
 [package.dependencies]
-py = ">=1.5.0"
-six = ">=1.10.0"
-setuptools = "*"
 attrs = ">=17.4.0"
+colorama = "*"
 more-itertools = ">=4.0.0"
 pluggy = ">=0.5,<0.7"
-funcsigs = {"version" = "*", "python" = "<3.0"}
-colorama = "*"
+py = ">=1.5.0"
+setuptools = "*"
+six = ">=1.10.0"
+
+[package.dependencies.funcsigs]
+python = "<3.0"
+version = "*"
 
 [[package]]
-name = "six"
-version = "1.11.0"
-description = "Python 2 and 3 compatibility utilities"
 category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
 optional = false
 python-versions = "*"
+version = "1.11.0"
+
+[[package.files]]
+hash = "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+name = "six-1.11.0-py2.py3-none-any.whl"
+packagetype = "bdist_wheel"
+
+[[package.files]]
+hash = "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+name = "six-1.11.0.tar.gz"
+packagetype = "sdist"
 
 [metadata]
-python-versions = "*"
 content-hash = "123456789"
+python-versions = "*"
 
 [metadata.hashes]
 attrs = ["1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9", "a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"]

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -255,3 +255,29 @@ def test_get_package_retrieves_packages_with_no_hashes():
     package = repo.package("jupyter", "1.0.0")
 
     assert [] == package.hashes
+
+
+def test_get_package_retrieves_non_sha256_hashes_in_files():
+    repo = MockRepository()
+
+    package = repo.package("ipython", "7.5.0")
+
+    expected = {
+        "ipython-7.5.0.tar.gz": "e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26",
+        "ipython-7.5.0-py3-none-any.whl": "md5:dbdc53e3918f28fa335a173432402a00",
+    }
+
+    assert len(package.files) == 2
+
+    for file in package.files:
+        assert file["hash"] == expected[file["name"]]
+
+
+def test_get_package_retrieves_packages_with_no_hashes_in_files():
+    repo = MockRepository()
+
+    package = repo.package("jupyter", "1.0.0")
+
+    file = package.files[0]
+    assert "hash" not in file
+    assert file["name"] == "jupyter-1.0.0.tar.gz"


### PR DESCRIPTION
This is so files can be distinguished based on their meta attributes.
My proposed solution to https://github.com/sdispater/poetry/issues/1172.

`metadata.hashes` is still around though I'd like to start seeing that as deprecated and only for backwards compatibility.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.