### PR TITLE
Add poetry-version attribute to poetry.lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -972,6 +972,7 @@ testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
 content-hash = "f3163ab56506c745d9250f9c04ea512d4996068c85770092590ffb079b465db0"
+poetry-version = "1.0.0a4"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.hashes]

--- a/poetry.lock
+++ b/poetry.lock
@@ -96,7 +96,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.3.9"
+version = "2019.6.16"
 
 [[package]]
 category = "dev"
@@ -287,7 +287,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.4"
+version = "1.4.5"
 
 [package.extras]
 license = ["editdistance"]
@@ -306,14 +306,14 @@ description = "Read metadata from Python packages"
 name = "importlib-metadata"
 optional = false
 python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.17"
+version = "0.18"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.dependencies.configparser]
 python = "<3"
-version = "*"
+version = ">=3.5"
 
 [package.dependencies.contextlib2]
 python = "<3"
@@ -903,7 +903,7 @@ marker = "python_version >= \"2.7\" and python_version < \"2.8\" or python_versi
 name = "typing"
 optional = false
 python-versions = "*"
-version = "3.6.6"
+version = "3.7.4"
 
 [[package]]
 category = "main"
@@ -936,7 +936,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "16.6.0"
+version = "16.6.1"
 
 [package.extras]
 docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
@@ -982,7 +982,7 @@ attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0
 black = ["09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf", "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"]
 cachecontrol = ["cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7"]
 cachy = ["b71513e5a38ce90c1280c02b7d8d6bb3fdf64666c9cc0584f2479afea097d56c", "b71e8e7ddb5b386e23e81befdfac8a93885406139b8681bedc17b3444fcb8fca"]
-certifi = ["59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5", "b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"]
+certifi = ["046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939", "945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"]
 cfgv = ["32edbe09de6f4521224b87822103a8c16a614d31a894735f7a5b3bcf0eb3c37e", "3bd31385cd2bebddbba8012200aaf15aa208539f1b33973759b4d02fc2148da5"]
 chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
 cleo = ["58d26642fa608a1515093275cd98875100c7d50f01fc1f3bbb7a78dbb73e4b14", "9b7d706309412e43d00723ed3074a300cd7879a0c685f4fef0b5052d7f4ab71f"]
@@ -1000,9 +1000,9 @@ futures = ["9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265", "
 glob2 = ["f5b0a686ff21f820c4d3f0c4edd216704cea59d79d00fa337e244a2f2ff83ed6"]
 html5lib = ["20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3", "66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"]
 httpretty = ["01b52d45077e702eda491f4fe75328d3468fd886aed5dcc530003e7b2b5939dc"]
-identify = ["3e8268640da8fa2a62acd5af2c299c45597a9a845d6706b3c19ddd5a46fb32dd", "78fcb1bdd37f4ecc954e8cba01680054781412a8aac82aed1998d8b5c8488011"]
+identify = ["0a11379b46d06529795442742a043dc2fa14cd8c995ae81d1febbc5f1c014c87", "43a5d24ffdb07bc7e21faf68b08e9f526a1f41f0056073f480291539ef961dfd"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
-importlib-metadata = ["a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f", "df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"]
+importlib-metadata = ["6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7", "cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"]
 importlib-resources = ["6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b", "d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"]
 jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
 jsonschema = ["0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d", "a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"]
@@ -1043,9 +1043,9 @@ toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235
 tomlkit = ["d6506342615d051bc961f70bfcfa3d29b6616cc08a3ddfd4bc24196f16fd4ec2", "f077456d35303e7908cc233b340f71e0bec96f63429997f38ca9272b7d64029e"]
 tornado = ["0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d", "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409", "732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f", "8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f", "8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5", "d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb", "e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"]
 tox = ["f5c8e446b51edd2ea97df31d4ded8c8b72e7d6c619519da6bb6084b9dd5770f9", "f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f"]
-typing = ["4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d", "57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4", "a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"]
+typing = ["38566c558a0a94d6531012c8e917b1b8518a41e418f7f15f00e129cc80162ad3", "53765ec4f83a2b720214727e319607879fec4acde22c4fbb54fa2604e79e44ce", "84698954b4e6719e912ef9a42a2431407fe3755590831699debda6fba92aac55"]
 urllib3 = ["2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4", "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb", "b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1", "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"]
-virtualenv = ["99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0", "fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"]
+virtualenv = ["b7335cddd9260a3dd214b73a2521ffc09647bde3e9457fcca31dc3be3999d04a", "d28ca64c0f3f125f59cabf13e0a150e1c68e5eea60983cc4395d88c584495783"]
 wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
 webencodings = ["a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"]
 zipp = ["8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d", "ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"]

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -11,6 +11,7 @@ from typing import List
 from poetry.utils._compat import Path
 from poetry.utils.toml_file import TomlFile
 from poetry.version.markers import parse_marker
+from poetry import __version__
 
 
 class Locker(object):
@@ -155,6 +156,7 @@ class Locker(object):
             }
 
         lock["metadata"] = {
+            "poetry-version": __version__,
             "python-versions": root.python_versions,
             "content-hash": self._content_hash,
             "hashes": hashes,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,9 @@ from poetry.packages import Package
 
 from poetry.utils._compat import Path
 
+from functools import wraps
+import tomlkit
+
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
 
@@ -28,3 +31,63 @@ def fixture(path=None):
         return FIXTURE_PATH / path
     else:
         return FIXTURE_PATH
+
+
+def assert_deepequals(a, b, ignore_paths=None, _path=None):
+    """Compare objects a and b keeping track of object path for error reporting.
+
+    Keyword arguments:
+    a -- Object a
+    b -- Object b
+    ignore_paths -- List of object paths (delimited by .)
+
+    Example:
+    assert_deepequals({
+        "poetry-version": "1.0.0a3",
+        "content-hash": "example",
+    }, {
+      "metadata": {
+        "poetry-version": "1.0.0a4",
+        "content-hash": "example",
+      }
+    }, ignore_paths=set(["metadata.poetry-version"]))
+    """
+
+    _path = _path if _path else tuple()
+    ignore_paths = ignore_paths if ignore_paths else set()
+    path = ".".join(_path)
+    err = ValueError(f"{path}: {a} != {b}")
+
+    def make_path(entry):
+        return _path + (str(entry),)
+
+    if isinstance(a, list):
+        if not isinstance(b, list) or len(a) != len(b):
+            raise err
+
+        for idx, vals in enumerate(zip(a, b)):
+            p = make_path(idx)
+            if ".".join(p) not in ignore_paths:
+                assert_deepequals(*vals, _path=p, ignore_paths=ignore_paths)
+
+    elif isinstance(a, dict):
+        if not isinstance(b, dict):
+            raise err
+
+        for key in set(list(a.keys()) + list(b.keys())):
+            p = make_path(key)
+            if ".".join(p) not in ignore_paths:
+                assert_deepequals(a[key], b[key], _path=p, ignore_paths=ignore_paths)
+
+    elif a == b:
+        return
+
+    else:
+        raise err
+
+
+@wraps(assert_deepequals)
+def assert_deepequals_toml(a, b, **kwargs):
+    a = dict(tomlkit.parse(a))
+    b = dict(tomlkit.parse(b))
+    return assert_deepequals(a, b, **kwargs)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -56,7 +56,7 @@ def assert_deepequals(a, b, ignore_paths=None, _path=None):
     _path = _path if _path else tuple()
     ignore_paths = ignore_paths if ignore_paths else set()
     path = ".".join(_path)
-    err = ValueError(f"{path}: {a} != {b}")
+    err = ValueError("{path}: {a} != {b}".format(path=path, a=a, b=b))
 
     def make_path(entry):
         return _path + (str(entry),)

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from functools import partial
 import sys
 
 import pytest
@@ -122,6 +123,12 @@ def env():
 @pytest.fixture()
 def installer(package, pool, locker, env, installed):
     return Installer(NullIO(), env, package, locker, pool, installed=installed)
+
+
+# Apply default path ignores (dynamic things like versions)
+assert_deepequals = partial(
+    assert_deepequals, ignore_paths=set(["metadata.poetry-version"])
+)
 
 
 def fixture(name):

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -18,6 +18,7 @@ from poetry.utils._compat import PY2
 from poetry.utils.toml_file import TomlFile
 from poetry.utils.env import NullEnv
 
+from tests.helpers import assert_deepequals
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 from tests.repositories.test_legacy_repository import (
@@ -126,14 +127,14 @@ def installer(package, pool, locker, env, installed):
 def fixture(name):
     file = TomlFile(Path(__file__).parent / "fixtures" / "{}.test".format(name))
 
-    return file.read()
+    return dict(file.read())
 
 
 def test_run_no_dependencies(installer, locker):
     installer.run()
     expected = fixture("no-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_dependencies(installer, locker, repo, package):
@@ -148,7 +149,7 @@ def test_run_with_dependencies(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_after_removing_dependencies(
@@ -212,7 +213,7 @@ def test_run_update_after_removing_dependencies(
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 0
@@ -332,7 +333,7 @@ def test_run_whitelist_add(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_whitelist_remove(installer, locker, repo, package, installed):
@@ -381,7 +382,7 @@ def test_run_whitelist_remove(installer, locker, repo, package, installed):
     installer.run()
     expected = fixture("remove")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
     assert len(installer.installer.installs) == 1
     assert len(installer.installer.updates) == 0
     assert len(installer.installer.removals) == 1
@@ -406,7 +407,7 @@ def test_add_with_sub_dependencies(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-sub-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_python_versions(installer, locker, repo, package):
@@ -431,7 +432,7 @@ def test_run_with_python_versions(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-python-versions")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_optional_and_python_restricted_dependencies(
@@ -460,7 +461,7 @@ def test_run_with_optional_and_python_restricted_dependencies(
     installer.run()
     expected = fixture("with-optional-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installer = installer.installer
     # We should only have 2 installs:
@@ -497,7 +498,7 @@ def test_run_with_optional_and_platform_restricted_dependencies(
     installer.run()
     expected = fixture("with-platform-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installer = installer.installer
     # We should only have 2 installs:
@@ -526,7 +527,7 @@ def test_run_with_dependencies_extras(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies-extras")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_does_not_install_extras_if_not_requested(installer, locker, repo, package):
@@ -550,7 +551,7 @@ def test_run_does_not_install_extras_if_not_requested(installer, locker, repo, p
     expected = fixture("extras")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -579,7 +580,7 @@ def test_run_installs_extras_if_requested(installer, locker, repo, package):
     expected = fixture("extras")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -609,7 +610,7 @@ def test_run_installs_extras_with_deps_if_requested(installer, locker, repo, pac
     expected = fixture("extras-with-dependencies")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -659,7 +660,7 @@ def test_installer_with_pypi_repository(package, locker, installed):
 
     expected = fixture("with-pypi-repository")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_installs_with_local_file(installer, locker, repo, package):
@@ -672,7 +673,7 @@ def test_run_installs_with_local_file(installer, locker, repo, package):
 
     expected = fixture("with-file-dependency")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -691,7 +692,7 @@ def test_run_installs_with_local_poetry_directory_and_extras(
 
     expected = fixture("with-directory-dependency-poetry")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -713,7 +714,7 @@ def test_run_installs_with_local_poetry_directory_transitive(
 
     expected = fixture("with-directory-dependency-poetry-transitive")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -735,7 +736,7 @@ def test_run_installs_with_local_poetry_file_transitive(
 
     expected = fixture("with-file-dependency-transitive")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 3
 
@@ -753,7 +754,7 @@ def test_run_installs_with_local_setuptools_directory(
 
     expected = fixture("with-directory-dependency-setuptools")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 3
 
@@ -795,7 +796,7 @@ def test_run_with_prereleases(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-prereleases")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_changes_category_if_needed(installer, locker, repo, package):
@@ -836,7 +837,7 @@ def test_run_changes_category_if_needed(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-category-change")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_all_with_lock(installer, locker, repo, package):
@@ -873,7 +874,7 @@ def test_run_update_all_with_lock(installer, locker, repo, package):
     installer.run()
     expected = fixture("update-with-lock")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_with_locked_extras(installer, locker, repo, package):
@@ -942,7 +943,7 @@ def test_run_update_with_locked_extras(installer, locker, repo, package):
     installer.run()
     expected = fixture("update-with-locked-extras")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_install_duplicate_dependencies_different_constraints(
@@ -972,7 +973,7 @@ def test_run_install_duplicate_dependencies_different_constraints(
 
     expected = fixture("with-duplicate-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 3
@@ -1082,7 +1083,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock(
 
     expected = fixture("with-duplicate-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 3
@@ -1249,7 +1250,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
 
     expected = fixture("with-duplicate-dependencies-update")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 2
@@ -1280,7 +1281,7 @@ def test_installer_test_solver_finds_compatible_package_for_dependency_python_no
     installer.run()
 
     expected = fixture("with-conditional-dependency")
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
 
@@ -1464,21 +1465,21 @@ def test_update_multiple_times_with_split_dependencies_is_idempotent(
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert_deepequals(dict(locker.written_data), expected)
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert_deepequals(dict(locker.written_data), expected)
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_installer_can_install_dependencies_from_forced_source(

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -6,6 +6,7 @@ import tomlkit
 from poetry.packages.locker import Locker
 from poetry.packages.project_package import ProjectPackage
 
+from ..helpers import assert_deepequals_toml
 from ..helpers import get_package
 
 
@@ -62,7 +63,8 @@ A = ["123", "456"]
 B = []
 """
 
-    assert expected == content
+
+    assert_deepequals_toml(expected, content)
 
 
 def test_locker_properly_loads_extras(locker):
@@ -134,4 +136,4 @@ python-versions = "*"
 A = []
 """
 
-    assert expected == content
+    assert_deepequals_toml(expected, content)


### PR DESCRIPTION
I want to know what version of poetry created a lock file. 

This also changes some of the testing behaviour to make field data easier to work with. 

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
