### PR TITLE
Skip updating git dependencies if short hash match

### DIFF
--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -72,9 +72,11 @@ class Solver:
                                 pkg.source_reference = locked.source_reference
                                 break
 
-                        if (
-                            pkg.source_url != package.source_url
-                            or pkg.source_reference != package.source_reference
+                        if pkg.source_url != package.source_url or (
+                            pkg.source_reference != package.source_reference
+                            and not pkg.source_reference.startswith(
+                                package.source_reference
+                            )
                         ):
                             operations.append(Update(pkg, package))
                         else:

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1294,6 +1294,39 @@ def test_solver_git_dependencies_update_skipped(solver, repo, package, installed
     )
 
 
+def test_solver_git_dependencies_short_hash_update_skipped(
+    solver, repo, package, installed
+):
+    pendulum = get_package("pendulum", "2.0.3")
+    cleo = get_package("cleo", "1.0.0")
+    repo.add_package(pendulum)
+    repo.add_package(cleo)
+
+    demo = get_package("demo", "0.1.2")
+    demo.source_type = "git"
+    demo.source_url = "https://github.com/demo/demo.git"
+    demo.source_reference = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+    installed.add_package(demo)
+
+    package.add_dependency(
+        "demo", {"git": "https://github.com/demo/demo.git", "rev": "9cf87a2"}
+    )
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops,
+        [
+            {"job": "install", "package": pendulum},
+            {
+                "job": "install",
+                "package": get_package("demo", "0.1.2"),
+                "skipped": True,
+            },
+        ],
+    )
+
+
 def test_solver_can_resolve_directory_dependencies(solver, repo, package):
     pendulum = get_package("pendulum", "2.0.3")
     repo.add_package(pendulum)


### PR DESCRIPTION
This change ensures that short hashes are taken into consideration when
evaluating if the required version of the dependency is already
installed.

The previous implementation only skipped update of a git
dependencies if the revision specified in the pyproject.toml matched
the full hash of the installed package.

Resolves: #1157

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
