### PR TITLE
Show project version if no argument provided for version command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -384,8 +384,9 @@ poetry lock
 
 ## version
 
-This command bumps the version of the project
-and writes the new version back to `pyproject.toml`
+This command shows the current version of the project or bumps the version of 
+the project and writes the new version back to `pyproject.toml` if a valid
+bump rule is provided.
 
 The new version should ideally be a valid semver string or a valid bump rule:
 `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`.

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -6,20 +6,23 @@ from .command import Command
 class VersionCommand(Command):
 
     name = "version"
-    description = "Bumps the version of the project."
+    description = (
+        "Shows the version of the project or bumps it when a valid"
+        "bump rule is provided."
+    )
 
     arguments = [
         argument(
             "version",
             "The version number or the rule to update the version.",
             optional=True,
-            default="patch",
         )
     ]
 
     help = """\
-The version command bumps the version of the project
-and writes the new version back to <comment>pyproject.toml</>.
+The version command shows the current version of the project or bumps the version of 
+the project and writes the new version back to <comment>pyproject.toml</> if a valid
+bump rule is provided.
 
 The new version should ideally be a valid semver string or a valid bump rule:
 patch, minor, major, prepatch, preminor, premajor, prerelease.
@@ -38,19 +41,28 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
     def handle(self):
         version = self.argument("version")
 
-        version = self.increment_version(self.poetry.package.pretty_version, version)
-
-        self.line(
-            "Bumping version from <comment>{}</> to <info>{}</>".format(
+        if version:
+            version = self.increment_version(
                 self.poetry.package.pretty_version, version
             )
-        )
 
-        content = self.poetry.file.read()
-        poetry_content = content["tool"]["poetry"]
-        poetry_content["version"] = version.text
+            self.line(
+                "Bumping version from <comment>{}</> to <info>{}</>".format(
+                    self.poetry.package.pretty_version, version
+                )
+            )
 
-        self.poetry.file.write(content)
+            content = self.poetry.file.read()
+            poetry_content = content["tool"]["poetry"]
+            poetry_content["version"] = version.text
+
+            self.poetry.file.write(content)
+        else:
+            self.line(
+                "Project (<comment>{}</>) version is <info>{}</>".format(
+                    self.poetry.package.name, self.poetry.package.pretty_version
+                )
+            )
 
     def increment_version(self, version, rule):
         from poetry.semver import Version

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -1,4 +1,5 @@
 import pytest
+from cleo import CommandTester
 
 from poetry.console.commands import VersionCommand
 
@@ -36,3 +37,10 @@ def command():
 )
 def test_increment_version(version, rule, expected, command):
     assert expected == command.increment_version(version, rule).text
+
+
+def test_version_show(app):
+    command = app.find("version")
+    tester = CommandTester(command)
+    tester.execute()
+    assert "Project (simple-project) version is 1.2.3\n" == tester.io.fetch_output()


### PR DESCRIPTION
This changes the behavior of version command to show the current version
of the project if no arguments are provided.

Resolves: #629

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
