### PR TITLE
Add `default` property for Pool

### DIFF
--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -27,6 +27,12 @@ class Pool(BaseRepository):
         super(Pool, self).__init__()
 
     @property
+    def default(self):  # type: () -> Repository
+        if not self.has_default():
+            raise ValueError("Default repository does not exist.")
+        return self._repositories[0]
+
+    @property
     def repositories(self):  # type: () -> List[Repository]
         return self._repositories
 

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -1,6 +1,7 @@
 from poetry.installation.pip_installer import PipInstaller
 from poetry.io.null_io import NullIO
 from poetry.packages.package import Package
+from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
 from poetry.utils.env import NullEnv
 
@@ -23,3 +24,27 @@ def test_requirement():
     )
 
     assert expected == result
+
+
+def test_install_from_another_repo():
+    pool = Pool()
+
+    default = LegacyRepository("default", "https://default.com")
+    another = LegacyRepository("another", "https://another.com")
+
+    pool.add_repository(default, default=True)
+    pool.add_repository(another)
+
+    installer = PipInstaller(NullEnv(), NullIO(), pool)
+
+    foo = Package("foo", "0.0.0")
+    foo.source_type = "legacy"
+    foo.source_reference = default._name
+    foo.source_url = default._url
+    bar = Package("bar", "0.1.0")
+    bar.source_type = "legacy"
+    bar.source_reference = another._name
+    bar.source_url = another._url
+
+    installer.install(foo)
+    installer.install(bar)

--- a/tests/repositories/test_pool.py
+++ b/tests/repositories/test_pool.py
@@ -69,3 +69,15 @@ def test_repository_with_normal_default_and_secondary_repositories():
     assert pool.repository("foo") is repo1
     assert pool.repository("bar") is repo2
     assert pool.has_default()
+
+
+def test_default_property():
+    pool = Pool()
+
+    with pytest.raises(ValueError):
+        pool.default
+
+    default = LegacyRepository("default", "https://default.com")
+    pool.add_repository(default, default=True)
+
+    assert pool.default == default


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

---

I have some issues with installing packages from a private repository. (#1163)
In `PipInstaller`, the installer checks `self._pool.default` repository to determine it is default or not. But there is no `default` attribute in `Pool`.
I think it was a mistake. So I added a property `default` to solve this problem.

