### PR TITLE
Set path in shell

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -348,6 +348,9 @@ The `shell` command spawns a shell,
 according to the `$SHELL` environment variable,
 within the virtual environment.
 If one doesn't exist yet, it will be created.
+The `$POETRY_ACTIVE` environment variable is set to `1`
+and the `$POETRY_PYTHON_PATH` is set to the
+`bin/` directory in the virtual environment.
 
 ```bash
 poetry shell

--- a/poetry/console/commands/shell.py
+++ b/poetry/console/commands/shell.py
@@ -35,6 +35,8 @@ If one doesn't exist yet, it will be created.
 
         # Setting this to avoid spawning unnecessary nested shells
         environ["POETRY_ACTIVE"] = "1"
+        environ["POETRY_PYTHON_PATH"] = "{}/bin".format(self.env.path)
         shell = Shell.get()
         self.env.execute(shell.path)
+        environ.pop("POETRY_PYTHON_PATH")
         environ.pop("POETRY_ACTIVE")


### PR DESCRIPTION
`poetry shell` never worked properly for me. Other people reported this in https://github.com/sdispater/poetry/issues/497 and https://github.com/sdispater/poetry/issues/571 but the solutions and workarounds mentioned never worked for me.

The reason is that early on in my shell's config, I reset `PATH` to a known state and go on to build it up from there. So, even though poetry sets it properly, my config undoes it.

My solution: test `POETRY_ACTIVE` and then append `POETRY_PYTHON_PATH` to `PATH`.

Notes:
- I don't know if `POETRY_PYTHON_PATH` is ideal, since `PYTHONPATH` already exists and is used differently. Maybe `POETRY_PYTHON_BIN` or `POETRY_PYTHON_BIN_PATH` or maybe something else would be better.
- I don't have any tests for this, sorry.

Checklist
- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
