### PR TITLE
Explicitly import io.open

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from io import open
 
 from subprocess import CalledProcessError
 


### PR DESCRIPTION
Fixes bug on Python 2.7, introduced in #1088, where `open` is used with an explicit encoding, without redefining `open` to be `io.open`

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
