### PR TITLE
Export command: fixes missing environment marker

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -12,6 +12,11 @@ class ExportCommand(Command):
     options = [
         option("format", "f", "Format to export to.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
+        option(
+            "without-markers",
+            None,
+            "Exclude package environment marker from the exported file.",
+        ),
         option("dev", None, "Include development dependencies."),
     ]
 
@@ -49,5 +54,6 @@ class ExportCommand(Command):
             fmt,
             self.poetry.file.parent,
             with_hashes=not self.option("without-hashes"),
+            with_markers=not self.option("without-markers"),
             dev=self.option("dev"),
         )

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -14,18 +14,18 @@ class Exporter(object):
         self._lock = lock
 
     def export(
-        self, fmt, cwd, with_hashes=True, dev=False
-    ):  # type: (str, Path, bool, bool) -> None
+        self, fmt, cwd, with_hashes=True, with_markers=True, dev=False
+    ):  # type: (str, Path, bool, bool, bool) -> None
         if fmt not in self.ACCEPTED_FORMATS:
             raise ValueError("Invalid export format: {}".format(fmt))
 
         getattr(self, "_export_{}".format(fmt.replace(".", "_")))(
-            cwd, with_hashes=with_hashes, dev=dev
+            cwd, with_hashes=with_hashes, with_markers=with_markers, dev=dev
         )
 
     def _export_requirements_txt(
-        self, cwd, with_hashes=True, dev=False
-    ):  # type: (Path, bool, bool) -> None
+        self, cwd, with_hashes=True, with_markers=True, dev=False
+    ):  # type: (Path, bool, bool, bool) -> None
         filepath = cwd / "requirements.txt"
         content = ""
 
@@ -44,6 +44,12 @@ class Exporter(object):
                 line += package.source_url
             else:
                 line = "{}=={}".format(package.name, package.version.text)
+                if with_markers:
+                    marker_str = str(package.marker)
+                    # need to test generated marker string for emptiness because there
+                    # is multiple types of empty marker
+                    if len(marker_str) > 0:
+                        line += ";" + marker_str
 
                 if package.source_type == "legacy" and package.source_url:
                     line += " \\\n"

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -403,3 +403,81 @@ foo==1.2.3 \\
 """
 
     assert expected == content
+
+
+def test_exporter_can_export_requirements_txt_with_package_marker(tmp_dir, locker):
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "marker": 'sys_platform == "darwin"',
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": [], "bar": []},
+            },
+        }
+    )
+    exporter = Exporter(locker)
+
+    exporter.export("requirements.txt", Path(tmp_dir), with_markers=True)
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+bar==4.5.6
+foo==1.2.3;sys_platform == "darwin"
+"""
+
+    assert expected == content
+
+
+def test_exporter_can_export_requirements_txt_with_empty_package_marker(
+    tmp_dir, locker
+):
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "marker": "",
+                }
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": [], "bar": []},
+            },
+        }
+    )
+    exporter = Exporter(locker)
+
+    exporter.export("requirements.txt", Path(tmp_dir), with_markers=True)
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+foo==1.2.3
+"""
+
+    assert expected == content


### PR DESCRIPTION
This PR fixes issue #1011 by adding new option to the export command, which appends environment marker according to [PEP-566 Environment markers](https://www.python.org/dev/peps/pep-0566/#id16).

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (no documentation updates is required because **export** section isn't fully covered)

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
