### PR TITLE
Use `os.execvp` for `poetry run`

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -40,15 +40,13 @@ class RunCommand(EnvCommand):
         cmd = ["python", "-c"]
 
         cmd += [
-            '"import sys; '
+            "import sys; "
             "from importlib import import_module; "
             "sys.argv = {!r}; {}"
-            "import_module('{}').{}()\"".format(
-                args, src_in_sys_path, module, callable_
-            )
+            "import_module('{}').{}()".format(args, src_in_sys_path, module, callable_)
         ]
 
-        return self.env.run(*cmd, shell=True, call=True)
+        return self.env.execute(*cmd)
 
     @property
     def _module(self):

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -712,7 +712,12 @@ class Env(object):
     def execute(self, bin, *args, **kwargs):
         bin = self._bin(bin)
 
-        return os.execvp(bin, [bin] + list(args), **kwargs)
+        if not self._is_windows:
+            return os.execvp(bin, [bin] + list(args))
+        else:
+            exe = subprocess.Popen([bin] + list(args), **kwargs)
+            exe.communicate()
+            return exe.returncode
 
     def is_venv(self):  # type: () -> bool
         raise NotImplementedError()

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -712,7 +712,7 @@ class Env(object):
     def execute(self, bin, *args, **kwargs):
         bin = self._bin(bin)
 
-        return subprocess.call([bin] + list(args), **kwargs)
+        return os.execvp(bin, [bin] + list(args), **kwargs)
 
     def is_venv(self):  # type: () -> bool
         raise NotImplementedError()

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -713,7 +713,11 @@ class Env(object):
         bin = self._bin(bin)
 
         if not self._is_windows:
-            return os.execvp(bin, [bin] + list(args))
+            args = [bin] + list(args)
+            if "env" in kwargs:
+                return os.execvpe(bin, args, kwargs["env"])
+            else:
+                return os.execvp(bin, args)
         else:
             exe = subprocess.Popen([bin] + list(args), **kwargs)
             exe.communicate()


### PR DESCRIPTION
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
------

This resolves #993.

`poetry run` uses `subprocess.call` to run the other program, making poetry spawn a new child process.
The problem is when `SIGTERM` is handed over; poetry does not pass it to the child process, instead terminates itself and makes zombie processes.
So I changed `poetry run` to use `os.execvp`, so poetry will replace itself with a new process and properly handle signals.

## Test

I made this small script in `poetry/tester.py`:

```python
import signal
import time


def handler(signum, frame):
    print(f"signal {signum} received")


def main():
    print("start")
    signal.signal(signal.SIGTERM, handler)
    time.sleep(10)
    print("end")


if __name__ == "__main__":
    main()
```

Then ran `poetry run python poetry/tester.py` and tried to kill it.

### Before

```bash
$ poetry run python poetry/tester.py &
[1] 23987
start
$ ps -ax | grep tester
24270 pts/11   S      0:00 python /home/.../poetry run python poetry/tester.py
24350 pts/11   S      0:00 /home/.../python poetry/tester.py
24359 pts/11   S+     0:00 grep --color=auto tester
$ kill -TERM $!
[1]+  Terminated              poetry run python poetry/tester.py
$ ps -ax | grep tester
24350 pts/11   S      0:00 /home/.../python poetry/tester.py
24446 pts/11   S+     0:00 grep --color=auto tester
$ 
end
```

### Fixed

```bash
$ python -m poetry run python poetry/tester.py &
[1] 25282
start
$ ps -ax | grep tester
25282 pts/11   S      0:00 /home/.../python poetry/tester.py
25364 pts/11   S+     0:00 grep --color=auto tester
$ kill -TERM $!
signal 15 received
$ 
end
[1]+  Done                    python -m poetry run python poetry/tester.py
```

## Test - scripts feature

I added the following lines to `pyprojects.toml`.

```toml
...
[tools.poetry.scripts]
...
tester = "poetry.tester:main"
```

Then ran `poetry run tester` and tried to kill it.

### Before

```bash
$ poetry run tester &
[1] 27077
start
$ ps -ax | grep tester
27077 pts/11   S      0:00 python /home/.../poetry run tester
27173 pts/11   S      0:00 /home/.../python -c import sys; from importlib import import_module; sys.argv = ['tester']; import_module('poetry.tester').main()
27189 pts/11   S+     0:00 grep --color=auto tester
$ kill -TERM $!
[1]+  Terminated              poetry run tester
$ ps -ax | grep tester
27173 pts/11   S      0:00 /home/.../python -c import sys; from importlib import import_module; sys.argv = ['tester']; import_module('poetry.tester').main()
27266 pts/11   S+     0:00 grep --color=auto tester
$ 
end
```

### Fixed

```bash
$ python -m poetry run tester &
[1] 27996
start
$ ps -ax | grep tester
27996 pts/11   S      0:00 /home/.../python -c import sys; from importlib import import_module; sys.argv = ['tester']; import_module('poetry.tester').main()
28082 pts/11   S+     0:00 grep --color=auto tester
$ kill -TERM $!
signal 15 received
$ 
end
[1]+  Done                    python -m poetry run tester
```