### PR TITLE
Force an update when changing a dependency to point to a local directory

### DIFF
--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -84,6 +84,13 @@ class Solver:
                     elif package.version != pkg.version:
                         # Checking version
                         operations.append(Update(pkg, package))
+                    elif (
+                        package.source_type == "directory"
+                        and pkg.source_type != "directory"
+                    ):
+                        # If we are changing to installing from a local directory, force
+                        # the install to take place.
+                        operations.append(Update(pkg, package))
                     else:
                         operations.append(Install(package).skip("Already installed"))
 


### PR DESCRIPTION
This fixes the following bug:

* Your pyproject.toml references a dependency
```
[tool.poetry.dependencies]
my-dependency = "^1.0.0"
```
* You realise you need to make parallel changes to the dependency, so you change the reference to point to a local checkout of the dependency:
```
[tool.poetry.dependencies]
my-dependency = { path = "../my-dependency/" }
```
* You run `poetry update` - but nothing happens.  It insists that the dependency is already installed, and we continue to use the installed copy in `site-packages`. Worse, `poetry show` now believes that you are using the local directory, even though you're not (as `pip show` confirms).