### PR TITLE
Fix mkdir breaking due to #1123

### DIFF
--- a/poetry/masonry/api.py
+++ b/poetry/masonry/api.py
@@ -37,7 +37,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     builder = WheelBuilder(poetry, SystemEnv(Path(sys.prefix)), NullIO())
 
     dist_info = Path(metadata_directory, builder.dist_info)
-    dist_info.mkdir()
+    dist_info.mkdir(parents=True, exist_ok=True)
 
     if "scripts" in poetry.local_config or "plugins" in poetry.local_config:
         with (dist_info / "entry_points.txt").open("w", encoding="utf-8") as f:


### PR DESCRIPTION
Mkdir is breaking when folder is already existing, this allows it not to fail if target exists

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
