### PR TITLE
Create config directory if not exists

### DIFF
--- a/poetry/config.py
+++ b/poetry/config.py
@@ -100,6 +100,8 @@ class Config:
         if self._file.exists():
             fd = str(self._file)
         else:
+            if not self._file.parent.exists():
+                os.mkdir(self._file.parent)
             umask_original = os.umask(umask)
             try:
                 fd = os.open(str(self._file), os.O_WRONLY | os.O_CREAT, mode)


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

---

Poetry seems to generate configuration file (`config.toml`) if not exists but does not make configuration directory (`~/.config/pypoetry`, for example).
So I think it would be great if poetry generates configuration directory, too.
