### PR TITLE
Add support for url dependencies

### DIFF
--- a/docs/docs/versions.md
+++ b/docs/docs/versions.md
@@ -113,6 +113,24 @@ my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
     You can install path dependencies in editable/development mode.
     Just pass `--develop my-package` (repeatable as much as you want) to
     the `install` command.
+    
+    
+### `url` dependencies
+
+To depend on a library located on a remote archive,
+you can use the `url` property:
+
+```toml
+[tool.poetry.dependencies]
+# directory
+my-package = { url = "https://example.com/my-package-0.1.0.tar.gz" }
+```
+
+with the corresponding `add` call:
+
+```bash
+poetry add https://example.com/my-package-0.1.0.tar.gz
+```
 
 
 ### Python restricted dependencies

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -76,7 +76,11 @@ If you do not specify a version constraint, poetry will choose a suitable one ba
             for key in poetry_content[section]:
                 if key.lower() == name.lower():
                     pair = self._parse_requirements([name])[0]
-                    if "git" in pair or pair.get("version") == "latest":
+                    if (
+                        "git" in pair
+                        or "url" in pair
+                        or pair.get("version") == "latest"
+                    ):
                         continue
 
                     raise ValueError("Package {} is already present".format(name))

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -211,6 +211,9 @@
                             "$ref": "#/definitions/path-dependency"
                         },
                         {
+                            "$ref": "#/definitions/url-dependency"
+                        },
+                        {
                             "$ref": "#/definitions/multiple-constraints-dependency"
                         }
                     ]
@@ -391,6 +394,42 @@
                 "develop": {
                     "type": "boolean",
                     "description": "Whether to install the dependency in development mode."
+                }
+            }
+        },
+        "url-dependency": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The url to the file."
+                },
+                "python": {
+                    "type": "string",
+                    "description": "The python versions for which the dependency should be installed."
+                },
+                "platform": {
+                    "type": "string",
+                    "description": "The platform(s) for which the dependency should be installed."
+                },
+                "markers": {
+                    "type": "string",
+                    "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+                },
+                "optional": {
+                    "type": "boolean",
+                    "description": "Whether the dependency is optional or not."
+                },
+                "extras": {
+                    "type": "array",
+                    "description": "The required extras for this dependency.",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/poetry/packages/__init__.py
+++ b/poetry/packages/__init__.py
@@ -20,6 +20,7 @@ from .utils.utils import is_installable_dir
 from .utils.utils import is_url
 from .utils.utils import path_to_url
 from .utils.utils import strip_extras
+from .url_dependency import URLDependency
 from .vcs_dependency import VCSDependency
 
 

--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -171,6 +171,9 @@ class Dependency(object):
     def is_directory(self):
         return False
 
+    def is_url(self):
+        return False
+
     def accepts(self, package):  # type: (poetry.packages.Package) -> bool
         """
         Determines if the given package matches this dependency.

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -18,8 +18,8 @@ from .constraints import parse_constraint as parse_generic_constraint
 from .dependency import Dependency
 from .directory_dependency import DirectoryDependency
 from .file_dependency import FileDependency
+from .url_dependency import URLDependency
 from .vcs_dependency import VCSDependency
-from .utils.utils import convert_markers
 from .utils.utils import create_nested_marker
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+)(?: <(?P<email>.+?)>)?$")
@@ -111,7 +111,7 @@ class Package(object):
 
     @property
     def full_pretty_version(self):
-        if self.source_type in ["file", "directory"]:
+        if self.source_type in ["file", "directory", "url"]:
             return "{} {}".format(self._pretty_version, self.source_url)
 
         if self.source_type not in ["hg", "git"]:
@@ -314,6 +314,8 @@ class Package(object):
                         base=self.root_dir,
                         develop=constraint.get("develop", True),
                     )
+            elif "url" in constraint:
+                dependency = URLDependency(name, constraint["url"], category=category)
             else:
                 version = constraint["version"]
 

--- a/poetry/packages/url_dependency.py
+++ b/poetry/packages/url_dependency.py
@@ -1,0 +1,40 @@
+from poetry.utils._compat import urlparse
+
+from .dependency import Dependency
+
+
+class URLDependency(Dependency):
+    def __init__(
+        self,
+        name,
+        url,  # type: str
+        category="main",  # type: str
+        optional=False,  # type: bool
+    ):
+        self._url = url
+
+        parsed = urlparse.urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError("{} does not seem like a valid url".format(url))
+
+        super(URLDependency, self).__init__(
+            name, "*", category=category, optional=optional, allows_prereleases=True
+        )
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def base_pep_508_name(self):  # type: () -> str
+        requirement = self.pretty_name
+
+        if self.extras:
+            requirement += "[{}]".format(",".join(self.extras))
+
+        requirement += " @ {}".format(self._url)
+
+        return requirement
+
+    def is_url(self):  # type: () -> bool
+        return True

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -39,6 +39,7 @@ from poetry.semver import VersionConstraint
 from poetry.semver import VersionRange
 from poetry.utils._compat import Path
 from poetry.utils.helpers import canonicalize_name
+from poetry.utils.inspector import Inspector
 from poetry.utils.patterns import wheel_file_re
 from poetry.version.markers import InvalidMarker
 
@@ -163,8 +164,8 @@ class LegacyRepository(PyPiRepository):
         self._name = name
         self._url = url.rstrip("/")
         self._auth = auth
+        self._inspector = Inspector()
         self._cache_dir = Path(CACHE_DIR) / "cache" / "repositories" / name
-
         self._cache = CacheManager(
             {
                 "default": "releases",

--- a/poetry/utils/inspector.py
+++ b/poetry/utils/inspector.py
@@ -1,0 +1,236 @@
+from typing import Dict
+from typing import List
+from typing import Union
+
+import logging
+import os
+import tarfile
+import zipfile
+from bz2 import BZ2File
+from gzip import GzipFile
+
+import pkginfo
+from requests import get
+
+from ._compat import Path
+from .helpers import parse_requires
+from .setup_reader import SetupReader
+from .toml_file import TomlFile
+
+logger = logging.getLogger(__name__)
+
+
+class Inspector:
+    """
+    A class to download and inspect remote packages.
+    """
+
+    @classmethod
+    def download(cls, url, dest):  # type: (str, Path) -> None
+        r = get(url, stream=True)
+        r.raise_for_status()
+
+        with open(str(dest), "wb") as f:
+            for chunk in r.iter_content(chunk_size=1024):
+                if chunk:
+                    f.write(chunk)
+
+    def inspect(self, file_path):  # type: (Path) -> Dict[str, Union[str, List[str]]]
+        if file_path.suffix == ".whl":
+            return self.inspect_wheel(file_path)
+
+        return self.inspect_sdist(file_path)
+
+    def inspect_wheel(
+        self, file_path
+    ):  # type: (Path) -> Dict[str, Union[str, List[str]]]
+        info = {
+            "name": "",
+            "version": "",
+            "summary": "",
+            "requires_python": None,
+            "requires_dist": None,
+        }
+
+        try:
+            meta = pkginfo.Wheel(str(file_path))
+        except ValueError:
+            # Unable to determine dependencies
+            # Assume none
+            return info
+
+        if meta.name:
+            info["name"] = meta.name
+
+        if meta.version:
+            info["version"] = meta.version
+
+        if meta.summary:
+            info["summary"] = meta.summary or ""
+
+        info["requires_python"] = meta.requires_python
+
+        if meta.requires_dist:
+            info["requires_dist"] = meta.requires_dist
+
+        return info
+
+    def inspect_sdist(
+        self, file_path
+    ):  # type: (Path) -> Dict[str, Union[str, List[str]]]
+        info = {
+            "name": "",
+            "version": "",
+            "summary": "",
+            "requires_python": None,
+            "requires_dist": None,
+        }
+
+        try:
+            meta = pkginfo.SDist(str(file_path))
+            if meta.name:
+                info["name"] = meta.name
+
+            if meta.version:
+                info["version"] = meta.version
+
+            if meta.summary:
+                info["summary"] = meta.summary
+
+            if meta.requires_python:
+                info["requires_python"] = meta.requires_python
+
+            if meta.requires_dist:
+                info["requires_dist"] = list(meta.requires_dist)
+
+                return info
+        except ValueError:
+            # Unable to determine dependencies
+            # We pass and go deeper
+            pass
+
+        # Still not dependencies found
+        # So, we unpack and introspect
+        suffix = file_path.suffix
+        gz = None
+        if suffix == ".zip":
+            tar = zipfile.ZipFile(str(file_path))
+        else:
+            if suffix == ".bz2":
+                gz = BZ2File(str(file_path))
+                suffixes = file_path.suffixes
+                if len(suffixes) > 1 and suffixes[-2] == ".tar":
+                    suffix = ".tar.bz2"
+            else:
+                gz = GzipFile(str(file_path))
+                suffix = ".tar.gz"
+
+            tar = tarfile.TarFile(str(file_path), fileobj=gz)
+
+        try:
+            tar.extractall(os.path.join(str(file_path.parent), "unpacked"))
+        finally:
+            if gz:
+                gz.close()
+
+            tar.close()
+
+        unpacked = file_path.parent / "unpacked"
+        elements = list(unpacked.glob("*"))
+        if len(elements) == 1 and elements[0].is_dir():
+            sdist_dir = elements[0]
+        else:
+            sdist_dir = unpacked / file_path.name.rstrip(suffix)
+
+        pyproject = TomlFile(sdist_dir / "pyproject.toml")
+        if pyproject.exists():
+            from poetry.poetry import Poetry
+
+            pyproject_content = pyproject.read()
+            if "tool" in pyproject_content and "poetry" in pyproject_content["tool"]:
+                package = Poetry.create(sdist_dir).package
+                return {
+                    "name": package.name,
+                    "version": package.version.text,
+                    "summary": package.description,
+                    "requires_dist": [dep.to_pep_508() for dep in package.requires],
+                    "requires_python": package.python_versions,
+                }
+
+        # Checking for .egg-info at root
+        eggs = list(sdist_dir.glob("*.egg-info"))
+        if eggs:
+            egg_info = eggs[0]
+
+            requires = egg_info / "requires.txt"
+            if requires.exists():
+                with requires.open(encoding="utf-8") as f:
+                    info["requires_dist"] = parse_requires(f.read())
+
+                    return info
+
+        # Searching for .egg-info in sub directories
+        eggs = list(sdist_dir.glob("**/*.egg-info"))
+        if eggs:
+            egg_info = eggs[0]
+
+            requires = egg_info / "requires.txt"
+            if requires.exists():
+                with requires.open(encoding="utf-8") as f:
+                    info["requires_dist"] = parse_requires(f.read())
+
+                    return info
+
+        # Still nothing, try reading (without executing it)
+        # the setup.py file.
+        try:
+            setup_info = self._inspect_sdist_with_setup(sdist_dir)
+
+            for key, value in info.items():
+                if value:
+                    continue
+
+                info[key] = setup_info[key]
+
+            return info
+        except Exception as e:
+            logger.warning(
+                "An error occurred when reading setup.py or setup.cfg: {}".format(
+                    str(e)
+                )
+            )
+            return info
+
+    def _inspect_sdist_with_setup(
+        self, sdist_dir
+    ):  # type: (Path) -> Dict[str, Union[str, List[str]]]
+        info = {
+            "name": None,
+            "version": None,
+            "summary": "",
+            "requires_python": None,
+            "requires_dist": None,
+        }
+
+        result = SetupReader.read_from_directory(sdist_dir)
+        requires = ""
+        for dep in result["install_requires"]:
+            requires += dep + "\n"
+
+        if result["extras_require"]:
+            requires += "\n"
+
+        for extra_name, deps in result["extras_require"].items():
+            requires += "[{}]\n".format(extra_name)
+
+            for dep in deps:
+                requires += dep + "\n"
+
+            requires += "\n"
+
+        info["name"] = result["name"]
+        info["version"] = result["version"]
+        info["requires_dist"] = parse_requires(requires)
+        info["requires_python"] = result["python_requires"]
+
+        return info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ except ImportError:
     import urlparse
 
 from poetry.config import Config
+from poetry.utils._compat import PY2
+from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import Path
 from poetry.utils.toml_file import TomlFile
 
@@ -43,8 +45,26 @@ def mock_clone(_, source, dest):
         / parts.path.lstrip("/").rstrip(".git")
     )
 
+    if dest.exists():
+        shutil.rmtree(str(dest))
+
     shutil.rmtree(str(dest))
     shutil.copytree(str(folder), str(dest))
+
+
+def mock_download(self, url, dest):
+    parts = urlparse.urlparse(url)
+
+    fixtures = Path(__file__).parent / "fixtures"
+    fixture = fixtures / parts.path.lstrip("/")
+
+    if dest.exists():
+        os.unlink(str(dest))
+
+    if PY2 and WINDOWS:
+        shutil.copyfile(str(fixture), str(dest))
+    else:
+        os.symlink(str(fixture), str(dest))
 
 
 @pytest.fixture
@@ -73,6 +93,12 @@ def git_mock(mocker):
     mocker.patch("poetry.vcs.git.Git.checkout", new=lambda *_: None)
     p = mocker.patch("poetry.vcs.git.Git.rev_parse")
     p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+
+
+@pytest.fixture(autouse=True)
+def download_mock(mocker):
+    # Patch download to not download anything but to just copy from fixtures
+    mocker.patch("poetry.utils.inspector.Inspector.download", new=mock_download)
 
 
 @pytest.fixture

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -17,6 +17,8 @@ from poetry.poetry import Poetry as BasePoetry
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories import Pool
 from poetry.repositories import Repository as BaseRepository
+from poetry.utils._compat import PY2
+from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import Path
 from poetry.utils.toml_file import TomlFile
 from poetry.repositories.exceptions import PackageNotFound
@@ -43,6 +45,21 @@ def mock_clone(self, source, dest):
     shutil.copytree(str(folder), str(dest))
 
 
+def mock_download(self, url, dest):
+    parts = urlparse.urlparse(url)
+
+    fixtures = Path(__file__).parent.parent / "fixtures"
+    fixture = fixtures / parts.path.lstrip("/")
+
+    if dest.exists():
+        shutil.rmtree(str(dest))
+
+    if PY2 and WINDOWS:
+        shutil.copyfile(str(fixture), str(dest))
+    else:
+        os.symlink(str(fixture), str(dest))
+
+
 @pytest.fixture
 def installed():
     return BaseRepository()
@@ -67,6 +84,9 @@ def setup(mocker, installer, installed, config):
     mocker.patch("poetry.vcs.git.Git.checkout", new=lambda *_: None)
     p = mocker.patch("poetry.vcs.git.Git.rev_parse")
     p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+
+    # Patch download to not download anything but to just copy from fixtures
+    mocker.patch("poetry.utils.inspector.Inspector.download", new=mock_download)
 
     # Setting terminal width
     environ = dict(os.environ)

--- a/tests/installation/fixtures/with-url-dependency.test
+++ b/tests/installation/fixtures/with-url-dependency.test
@@ -1,0 +1,35 @@
+[[package]]
+name = "demo"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.source]
+type = "url"
+reference = ""
+url = "https://poetry.eustace.io/distributions/demo-0.1.0-py2.py3-none-any.whl"
+
+[package.dependencies]
+pendulum = ">=1.4.4"
+
+[package.extras]
+bar = ["tomlkit"]
+foo = ["cleo"]
+
+[[package]]
+name = "pendulum"
+version = "1.4.4"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[metadata]
+python-versions = "*"
+content-hash = "123456789"
+
+[metadata.hashes]
+demo = []
+pendulum = []

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1499,3 +1499,18 @@ def test_installer_can_install_dependencies_from_forced_source(
     assert len(installer.installer.installs) == 1
     assert len(installer.installer.updates) == 0
     assert len(installer.installer.removals) == 0
+
+
+def test_run_installs_with_url_file(installer, locker, repo, package):
+    url = "https://poetry.eustace.io/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    package.add_dependency("demo", {"url": url})
+
+    repo.add_package(get_package("pendulum", "1.4.4"))
+
+    installer.run()
+
+    expected = fixture("with-url-dependency")
+
+    assert locker.written_data == expected
+
+    assert len(installer.installer.installs) == 2

--- a/tests/masonry/builders/fixtures/with_url_dependency/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_url_dependency/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.poetry]
+name = "with-url-dependency"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "Sébastien Eustace <sebastien@eustace.io>"
+]
+license = "MIT"
+
+homepage = "https://poetry.eustace.io/"
+repository = "https://github.com/sdispater/poetry"
+documentation = "https://poetry.eustace.io/docs"
+
+keywords = ["packaging", "dependency", "poetry"]
+
+classifiers = [
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+
+# Requirements
+[tool.poetry.dependencies]
+python = "^3.6"
+demo = { url = "https://poetry.eustace.io/distributions/demo-0.1.0-py2.py3-none-any.whl" }

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -132,3 +132,20 @@ def test_metadata_with_vcs_dependencies():
     requires_dist = metadata["Requires-Dist"]
 
     assert "cleo @ git+https://github.com/sdispater/cleo.git@master" == requires_dist
+
+
+def test_metadata_with_url_dependencies():
+    builder = Builder(
+        Poetry.create(Path(__file__).parent / "fixtures" / "with_url_dependency"),
+        NullEnv(),
+        NullIO(),
+    )
+
+    metadata = Parser().parsestr(builder.get_metadata_content())
+
+    requires_dist = metadata["Requires-Dist"]
+
+    assert (
+        "demo @ https://poetry.eustace.io/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        == requires_dist
+    )


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This PR adds support for URL dependencies.

Adding a URL dependency to the current project can be done in two ways: via the `add` command or by modifying the `pyproject.toml` file directly.

```bash
poetry add https://example.com/packages/my-package-1.0.0.tar.gz
```

```toml
[tool.poetry.dependencies]
my-package = {url = "https://example.com/packages/my-package-1.0.0.tar.gz"}
```
