### PR TITLE
Add support for PyPI API tokens

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -39,8 +39,18 @@ If you do not specify the password you will be prompted to write it.
 
 !!!note
 
-    To publish to PyPI, you can set your credentials for the repository
-    named `pypi`:
+    To publish to PyPI, you can set your credentials for the repository named `pypi`.
+
+    Note that it is recommended to use [API tokens](https://pypi.org/help/#apitoken)
+    when uploading packages to PyPI.
+    Once you have created a new token, you can tell Poetry to use it:
+
+    ```bash
+    poetry config pypi-token.pypi my-token
+    ```
+
+    If you still want to use you username and password, you can do so with the following
+    call to `config`.
 
     ```bash
     poetry config http-basic.pypi username password
@@ -56,6 +66,7 @@ Keyring support is enabled using the [keyring library](https://pypi.org/project/
 Alternatively, you can use environment variables to provide the credentials:
 
 ```bash
+export POETRY_PYPI_TOKEN_PYPI=my-token
 export POETRY_HTTP_BASIC_PYPI_USERNAME=username
 export POETRY_HTTP_BASIC_PYPI_PASSWORD=password
 ```

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -176,7 +176,7 @@ To remove a repository (repo is a short alias for repositories):
             )
 
         # handle auth
-        m = re.match(r"^(http-basic)\.(.+)", self.argument("key"))
+        m = re.match(r"^(http-basic|pypi-token)\.(.+)", self.argument("key"))
         if m:
             if self.option("unset"):
                 keyring_repository_password_del(config, m.group(2))
@@ -208,6 +208,17 @@ To remove a repository (repo is a short alias for repositories):
 
                 auth_config_source.add_property(
                     "{}.{}".format(m.group(1), m.group(2)), property_value
+                )
+            elif m.group(1) == "pypi-token":
+                if len(values) != 1:
+                    raise ValueError(
+                        "Expected only one argument (token), got {}".format(len(values))
+                    )
+
+                token = values[0]
+
+                auth_config_source.add_property(
+                    "{}.{}".format(m.group(1), m.group(2)), token
                 )
 
             return 0

--- a/poetry/console/commands/publish.py
+++ b/poetry/console/commands/publish.py
@@ -26,6 +26,8 @@ The --repository option should match the name of a configured repository using
 the config command.
 """
 
+    loggers = ["poetry.masonry.publishing.publisher"]
+
     def handle(self):
         from poetry.masonry.publishing.publisher import Publisher
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -92,3 +92,16 @@ virtualenvs.path = {path}  # /foo{sep}virtualenvs
     assert expected == tester.io.fetch_output()
 
     assert "poetry.toml" == init.call_args_list[2][0][1].path.name
+    assert expected == tester.io.fetch_output()
+
+
+def test_set_pypi_token(app, config_source, config_document, mocker):
+    init = mocker.spy(ConfigSource, "__init__")
+    command = app.find("config")
+    tester = CommandTester(command)
+
+    tester.execute("pypi-token.pypi mytoken")
+
+    tester.execute("--list")
+
+    assert "mytoken" == config_document["pypi-token"]["pypi"]


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

PyPI recently added support for token-based authentication to upload packages: https://pypi.org/help/#apitoken

This PR adds support for that use case in Poetry.

Users can now configure tokens via the `config` command:

```bash
poetry config pypi-token.pypi my-token
```

It's also possible to provide an environment variable holding the value of the token:

```bash
export POETRY_PYPI_TOKEN_PYPI=my-token
```


