### PR TITLE
export: add extras flag and exclude optional packages by default

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -442,6 +442,7 @@ poetry export -f requirements.txt > requirements.txt
 * `--output (-o)`: The name of the output file.  If omitted, print to standard
   output.
 * `--dev`: Include development dependencies.
+* `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.
 

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -1,6 +1,7 @@
+from cleo import option
+
 from poetry.utils.exporter import Exporter
 
-from cleo import option
 from .command import Command
 
 
@@ -14,6 +15,13 @@ class ExportCommand(Command):
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
         option("dev", None, "Include development dependencies."),
+        option(
+            "extras",
+            "E",
+            "Extra sets of dependencies to include.",
+            flag=False,
+            multiple=True,
+        ),
         option("with-credentials", None, "Include credentials for extra indices."),
     ]
 
@@ -55,5 +63,6 @@ class ExportCommand(Command):
             output or self.io,
             with_hashes=not self.option("without-hashes"),
             dev=self.option("dev"),
+            extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
         )


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

---

See #1284 for issue description and feature suggestion.

This PR introduces the `--extras` flag for `poetry export`, and changes the default behaviour to **exclude optional packages** from the exported `requirements.txt` file.

This is consistent with existing behaviour for two reasons:
- `export` already excludes `dev` packages by default
- `--extras` is required by `install` to install optional packages

While this is a breaking change, `export` has not currently been released, so there should be no barrier to this making it into version 1 if the feature is accepted.

Feedback time!
