### PR TITLE
Fix support for url sourced packages in pip installer

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -138,6 +138,9 @@ class PipInstaller(BaseInstaller):
                 package.source_url, package.source_reference, package.name
             )
 
+        if package.source_type == "url":
+            return "{}#egg={}".format(package.source_url, package.name)
+
         return "{}=={}".format(package.name, package.version)
 
     def create_temporary_requirement(self, package):

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -26,6 +26,19 @@ def test_requirement():
     assert expected == result
 
 
+def test_requirement_source_type_url():
+    installer = PipInstaller(NullEnv(), NullIO(), Pool())
+
+    foo = Package("foo", "0.0.0")
+    foo.source_type = "url"
+    foo.source_url = "https://somehwere.com/releases/foo-1.0.0.tar.gz"
+
+    result = installer.requirement(foo, formatted=True)
+    expected = "{}#egg={}".format(foo.source_url, foo.name)
+
+    assert expected == result
+
+
 def test_install_with_non_pypi_default_repository():
     pool = Pool()
 


### PR DESCRIPTION
This change fixes the installation of packages using a url source.
Previously, the installer attempted to install the package using the
name ignoring the source url.

Closes: #1297 

## Pull Request Check List
- [x] Added **tests** for changed code.
