### PR TITLE
Fix a silent upload error

### DIFF
--- a/poetry/masonry/publishing/uploader.py
+++ b/poetry/masonry/publishing/uploader.py
@@ -6,6 +6,7 @@ import re
 from typing import List
 
 import requests
+import requests.status_codes as status_codes
 
 from requests import adapters
 from requests.exceptions import HTTPError
@@ -228,6 +229,11 @@ class Uploader:
                 encoder, lambda monitor: bar.set_progress(monitor.bytes_read)
             )
 
+            # Check for a redirect first
+            resp = session.head(url)
+            if resp.status_code == status_codes.codes.moved:
+                url = resp.headers["Location"]
+
             bar.start()
 
             resp = session.post(
@@ -237,7 +243,7 @@ class Uploader:
                 headers={"Content-Type": monitor.content_type},
             )
 
-            if resp.ok:
+            if resp.status_code == status_codes.codes.ok:
                 bar.finish()
 
                 self._io.writeln("")

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -2,6 +2,7 @@ def test_publish_returns_non_zero_code_for_upload_errors(app, app_tester, http):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=400, body="Bad Request"
     )
+    http.register_uri(http.HEAD, "https://upload.pypi.org/legacy/")
 
     exit_code = app_tester.run(
         [("command", "publish"), ("--username", "foo"), ("--password", "bar")]
@@ -14,10 +15,10 @@ Publishing simple-project (1.2.3) to PyPI
  - Uploading simple-project-1.2.3.tar.gz 0%
  - Uploading simple-project-1.2.3.tar.gz 100%
  - Uploading simple-project-1.2.3.tar.gz 100%
-                               
-[UploadError]   
-HTTP Error 400: Bad Request  
-                               
+
+[UploadError]
+HTTP Error 400: Bad Request
+
 """
 
     assert app_tester.get_display(True).startswith(expected)


### PR DESCRIPTION
Fixes #858 by first issuing a HEAD request and following a redirect.
This does not cover further redirects though, so it's possible to make this more robust. It does cover the most common use cases (PyPI and TestPyPI will work correctly)

See my comment for more details: https://github.com/sdispater/poetry/issues/858#issuecomment-520239647

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (n/a: this is a bugfix)

