### PR TITLE
Respect Python version in bin script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It supports Python 2.7 and 3.4+.
 
 Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system by vendorizing its dependencies. This is the
-recommended way of installing `poetry`.
+recommended way of installing `poetry`. The installer installs a script to run Poetry, which will use the version of Python used to install Poetry.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -194,7 +194,7 @@ POETRY_LIB = os.path.join(POETRY_HOME, "lib")
 POETRY_LIB_BACKUP = os.path.join(POETRY_HOME, "lib-backup")
 
 
-BIN = """#!/usr/bin/env python
+BIN_TEMPLATE = """#!/usr/bin/env {python_executable_name}
 # -*- coding: utf-8 -*-
 import glob
 import sys
@@ -580,8 +580,10 @@ class Installer:
                 )
 
         with open(os.path.join(POETRY_BIN, "poetry"), "w", encoding="utf-8") as f:
-            f.write(u(BIN))
-
+            python_executable_name = os.path.basename(Installer.CURRENT_PYTHON)
+            f.write(
+                u(BIN_TEMPLATE.format(python_executable_name=python_executable_name))
+            )
         if not WINDOWS:
             # Making the file executable
             st = os.stat(os.path.join(POETRY_BIN, "poetry"))


### PR DESCRIPTION
- [ N/A ] Added **tests** for changed code.
- [ ✔️ ] Updated **documentation** for changed code.
---

This PR makes the Poetry installer `get-poetry.py` respect the installing version of Python in installing the `~/.poetry/bin/poetry` script. 

Simply, if `python3` is used to install Poetry, then use that as the Python executable to run Poetry as. If it is `python` (e.g. Python 2), then use `python`.

This should fix the issues some people are having in #1257.