### PR TITLE
Check to ensure the global config exists before reading

### DIFF
--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -73,7 +73,8 @@ To remove a repository (repo is a short alias for repositories):
         config = Config()
         config_file = TomlFile(Path(CONFIG_DIR) / "config.toml")
         config_source = ConfigSource(config_file)
-        config.merge(config_source.file.read())
+        if config_file.exists():
+            config.merge(config_source.file.read())
 
         auth_config_file = TomlFile(Path(CONFIG_DIR) / "auth.toml")
         auth_config_source = ConfigSource(auth_config_file, auth_config=True)

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -73,7 +73,7 @@ To remove a repository (repo is a short alias for repositories):
         config = Config()
         config_file = TomlFile(Path(CONFIG_DIR) / "config.toml")
         config_source = ConfigSource(config_file)
-        if config_file.exists():
+        if config_source.file.exists():
             config.merge(config_source.file.read())
 
         auth_config_file = TomlFile(Path(CONFIG_DIR) / "auth.toml")


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

---

#1272 introduced a bug on "develop" where poetry performs a blind read on the global config file without checking whether it exists first.  This is a one-line fix that simply checks to make sure the file exists before the read.  The existing follow-on code already handles creation of the file just fine.

This should close out #1179
