### PR TITLE
Add support for special characters in username/password for pip

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -21,6 +21,11 @@ from typing import Generator
 from typing import Optional
 from typing import Union
 
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
 import requests
 
 from cachecontrol import CacheControl
@@ -197,8 +202,8 @@ class LegacyRepository(PyPiRepository):
 
         return "{scheme}://{username}:{password}@{netloc}{path}".format(
             scheme=parsed.scheme,
-            username=self._auth.auth.username,
-            password=self._auth.auth.password,
+            username=quote(self._auth.auth.username),
+            password=quote(self._auth.auth.password),
             netloc=parsed.netloc,
             path=parsed.path,
         )

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -7,6 +7,7 @@ except ImportError:
     import urlparse
 
 from poetry.packages import Dependency
+from poetry.repositories.auth import Auth
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
@@ -18,9 +19,9 @@ class MockRepository(LegacyRepository):
 
     FIXTURES = Path(__file__).parent / "fixtures" / "legacy"
 
-    def __init__(self):
+    def __init__(self, auth=None):
         super(MockRepository, self).__init__(
-            "legacy", url="http://foo.bar", disable_cache=True
+            "legacy", url="http://foo.bar", auth=auth, disable_cache=True
         )
 
     def _get(self, endpoint):
@@ -255,3 +256,10 @@ def test_get_package_retrieves_packages_with_no_hashes():
     package = repo.package("jupyter", "1.0.0")
 
     assert [] == package.hashes
+
+
+def test_username_password_special_chars():
+    auth = Auth("http://foo.bar", "user:", "p@ssword")
+    repo = MockRepository(auth=auth)
+
+    assert "http://user%3A:p%40ssword@foo.bar" == repo.authenticated_url


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

----

Per #1249 and [pip #6776](pip/issues#6775), newer versions of pip require require the username and password to be properly encoded/quoted.  This PR simply `quote`s the URL when calling pip.

As referenced in #1249, we do not want to pre-quote the strings as that fouls up the metadata fetch which does not use pip.