### PR TITLE
Follow repo perm redirect

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -22,10 +22,13 @@ repository.
 Adding a new repository is easy with the `config` command.
 
 ```bash
-poetry config repositories.foo https://foo.bar/simple/
+poetry config repositories.testpypi https://test.pypi.org/legacy/
 ```
 
-This will set the url for repository `foo` to `https://foo.bar/simple/`.
+This will set the url for repository `testpypi` to `https://test.pypi.org/legacy/`.
+
+If the URL provided returns a permanent redirect, the redirect location will
+be saved instead. Most commonly, PyPI returns a redirect from `/legacy` to `/legacy/`.
 
 ### Configuring credentials
 

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -7,6 +7,7 @@ from cleo import option
 from poetry.utils.helpers import (
     keyring_repository_password_del,
     keyring_repository_password_set,
+    normalize_url,
 )
 from .command import Command
 
@@ -163,7 +164,7 @@ To remove a repository (repo is a short alias for repositories):
                 return 0
 
             if len(values) == 1:
-                url = values[0]
+                url = normalize_url(values[0])
 
                 config_source.add_property(
                     "repositories.{}.url".format(m.group(1)), url

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -152,3 +152,24 @@ def merge_dicts(d1, d2):
             merge_dicts(d1[k], d2[k])
         else:
             d1[k] = d2[k]
+
+
+def normalize_url(url):  # type: (str) -> str
+    """ Checks a URL for a permanent redirect and returns the redirect location
+        if there is one. If there is no redirect, it returns the same.
+    """
+    import requests
+
+    status_codes = requests.status_codes.codes
+    response = requests.head(url)
+    # The two status codes below are similar, but moved_permanently allows the
+    # agent to change a POST request to a GET (that's what requests does BTW
+    # when it is told to follow redirects).
+    # For poetry, as an agent, the only thing that matters is that both of these
+    # are permanent and cacheable.
+    if response.status_code in (
+        status_codes.moved_permanently,
+        status_codes.permanent_redirect,
+    ):
+        return response.headers["Location"]
+    return url

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,5 +1,4 @@
-from poetry.utils.helpers import get_http_basic_auth
-from poetry.utils.helpers import parse_requires
+from poetry.utils.helpers import get_http_basic_auth, parse_requires, normalize_url
 
 
 def test_parse_requires():
@@ -26,7 +25,7 @@ virtualenv>=15.2.0.0,<16.0.0.0
 pathlib2>=2.3.0.0,<3.0.0.0
 
 [:python_version >= "3.4.0.0" and python_version < "3.6.0.0"]
-zipfile36>=0.1.0.0,<0.2.0.0    
+zipfile36>=0.1.0.0,<0.2.0.0
 """
     result = parse_requires(requires)
     expected = [
@@ -65,3 +64,18 @@ def test_get_http_basic_auth_without_password(config):
 
 def test_get_http_basic_auth_missing(config):
     assert get_http_basic_auth(config, "foo") is None
+
+
+def test_normalize_url_when_redirect(http):
+    repo_url = "https://foopi.org/legacy"
+    redirect_url = repo_url + "/"
+    http.register_uri(
+        http.HEAD, repo_url, status=301, adding_headers={"location": redirect_url}
+    )
+    assert redirect_url == normalize_url(repo_url)
+
+
+def test_normalize_url_when_no_redirect(http):
+    repo_url = "https://foopi.org/legacy/"
+    http.register_uri(http.HEAD, repo_url, status=200)
+    assert repo_url == normalize_url(repo_url)


### PR DESCRIPTION
This PR supersedes https://github.com/sdispater/poetry/pull/1310 and fixes https://github.com/sdispater/poetry/issues/858

In the documentation, I took the liberty to change the "foo.bar" domain to that of TestPyPI, because it's a common URL that people might want to add.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

