### PR TITLE
Fix interactive dependencies behavior.

### DIFF
--- a/poetry/repositories/base_repository.py
+++ b/poetry/repositories/base_repository.py
@@ -13,6 +13,9 @@ class BaseRepository(object):
     def has_package(self, package):
         raise NotImplementedError()
 
+    def package_exists(self, package):
+        raise NotImplementedError()
+
     def package(self, name, version, extras=None):
         raise NotImplementedError()
 

--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -92,6 +92,13 @@ class Pool(BaseRepository):
     def has_package(self, package):
         raise NotImplementedError()
 
+    def package_exists(self, package):
+        for repository in self._repositories:
+            if repository is not self and repository.package_exists(package):
+                return True
+
+        return False
+
     def package(
         self, name, version, extras=None, repository=None
     ):  # type: (str, str, List[str], str) -> Package

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -296,6 +296,13 @@ class PyPiRepository(Repository):
 
         return cached
 
+    def package_exists(self, package):
+        try:
+            self.get_package_info(package)
+            return True
+        except PackageNotFound:
+            return False
+
     def _get_release_info(self, name, version):  # type: (str, str) -> dict
         self._log("Getting info for {} ({}) from PyPI".format(name, version), "debug")
 

--- a/poetry/repositories/repository.py
+++ b/poetry/repositories/repository.py
@@ -100,6 +100,13 @@ class Repository(BaseRepository):
 
         return False
 
+    def package_exists(self, package):
+        for repo_package in self.packages:
+            if package == repo_package.name:
+                return True
+
+        return False
+
     def add_package(self, package):
         self._packages.append(package)
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -65,13 +65,63 @@ def test_interactive_with_dependencies(app, repo, mocker, poetry):
         "MIT",  # License
         "~2.7 || ^3.6",  # Python
         "",  # Interactive packages
-        "pendulum",  # Search for package
+        "pendu",  # Search for package
         "0",  # First option
         "",  # Do not set constraint
         "",  # Stop searching for packages
         "",  # Interactive dev packages
-        "pytest",  # Search for package
+        "pyte",  # Search for package
         "0",
+        "",
+        "",
+        "\n",  # Generate
+    ]
+    tester.execute(inputs="\n".join(inputs))
+
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+pendulum = "^2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.6.0"
+"""
+
+    assert expected in tester.io.fetch_output()
+
+
+def test_interactive_with_exact_dependencies(app, repo, mocker, poetry):
+    repo.add_package(get_package("pendulum", "2.0.0"))
+    repo.add_package(get_package("pytest", "3.6.0"))
+
+    command = app.find("init")
+    command._pool = poetry.pool
+
+    mocker.patch("poetry.utils._compat.Path.open")
+    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p.return_value = Path(__file__).parent
+
+    tester = CommandTester(command)
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "",  # Interactive packages
+        "pendulum",  # Search for package
+        "",  # Do not set constraint
+        "",  # Stop searching for packages
+        "",  # Interactive dev packages
+        "pytest",  # Search for package
         "",
         "",
         "\n",  # Generate
@@ -161,7 +211,6 @@ def test_interactive_with_git_dependencies(app, repo, mocker, poetry):
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate
@@ -211,7 +260,6 @@ def test_interactive_with_git_dependencies_with_reference(app, repo, mocker, poe
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate
@@ -261,7 +309,6 @@ def test_interactive_with_git_dependencies_and_other_name(app, repo, mocker, poe
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate
@@ -311,7 +358,6 @@ def test_interactive_with_directory_dependency(app, repo, mocker, poetry):
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate
@@ -363,7 +409,6 @@ def test_interactive_with_directory_dependency_and_other_name(
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate
@@ -413,7 +458,6 @@ def test_interactive_with_file_dependency(app, repo, mocker, poetry):
         "",  # Stop searching for packages
         "",  # Interactive dev packages
         "pytest",  # Search for package
-        "0",
         "",
         "",
         "\n",  # Generate


### PR DESCRIPTION
This PR is meant to fix annoying behavior of the interactive dependencies filling during ``poetry init``.  
In current behavior, if you will try to add ``flake8``, ``flask`` or ``SQLAlchemy``, you will get a list of 100 packages, but none of them will be the one you're looking for. 

It seems it is a bug within the Pypi RPC API. Poetry is looking for the package by looking for any package with the given name in the package name **or** summary. The PyPi API bug seems to treat **or** as **and**. The API is already deprecated, and this functionality will still require changes.  

My change, however, has slightly worked around the faulty API. If the repository will have a package with exactly the same name as user wants, it will add it without listing packages with similar names. This will be more consistent, as the ``add`` method works the same. If the package with exactly the same name won't be found, it will fall back to the previous behavior.

This should resolve #528 and #547.