### PR TITLE
Allow uploading of wheels with local version identifier

### DIFF
--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -19,7 +19,7 @@ from poetry.__version__ import __version__
 from poetry.semver import parse_constraint
 from poetry.utils._compat import decode
 
-from ..utils.helpers import normalize_file_permissions
+from ..utils.helpers import normalize_file_permissions, escape_name, escape_version
 from ..utils.package_include import PackageInclude
 from ..utils.tags import get_abbr_impl
 from ..utils.tags import get_abi_tag
@@ -210,8 +210,8 @@ class WheelBuilder(Builder):
     @property
     def wheel_filename(self):  # type: () -> str
         return "{}-{}-{}.whl".format(
-            re.sub(r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE),
-            re.sub(r"[^\w\d.\+]+", "_", self._meta.version, flags=re.UNICODE),
+            escape_name(self._package.pretty_name),
+            escape_version(self._meta.version),
             self.tag,
         )
 
@@ -221,8 +221,8 @@ class WheelBuilder(Builder):
         )
 
     def dist_info_name(self, distribution, version):  # type: (...) -> str
-        escaped_name = re.sub(r"[^\w\d.]+", "_", distribution, flags=re.UNICODE)
-        escaped_version = re.sub(r"[^\w\d.+]+", "_", version, flags=re.UNICODE)
+        escaped_name = escape_name(distribution)
+        escaped_version = escape_version(version)
 
         return "{}-{}.dist-info".format(escaped_name, escaped_version)
 

--- a/poetry/masonry/publishing/uploader.py
+++ b/poetry/masonry/publishing/uploader.py
@@ -66,7 +66,7 @@ class Uploader:
                     re.sub(
                         r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE
                     ),
-                    re.sub(r"[^\w\d.]+", "_", version, flags=re.UNICODE),
+                    re.sub(r"[^\w\d.+]+", "_", version, flags=re.UNICODE),
                 )
             )
         )

--- a/poetry/masonry/publishing/uploader.py
+++ b/poetry/masonry/publishing/uploader.py
@@ -18,6 +18,7 @@ from poetry.utils.helpers import normalize_version
 from poetry.utils.patterns import wheel_file_re
 
 from ..metadata import Metadata
+from ..utils.helpers import escape_name, escape_version
 
 
 _has_blake2 = hasattr(hashlib, "blake2b")
@@ -63,10 +64,7 @@ class Uploader:
         wheels = list(
             dist.glob(
                 "{}-{}-*.whl".format(
-                    re.sub(
-                        r"[^\w\d.]+", "_", self._package.pretty_name, flags=re.UNICODE
-                    ),
-                    re.sub(r"[^\w\d.+]+", "_", version, flags=re.UNICODE),
+                    escape_name(self._package.pretty_name), escape_version(version)
                 )
             )
         )

--- a/poetry/masonry/utils/helpers.py
+++ b/poetry/masonry/utils/helpers.py
@@ -1,3 +1,6 @@
+import re
+
+
 def normalize_file_permissions(st_mode):
     """
     Normalizes the permission bits in the st_mode field from stat to 644/755
@@ -12,3 +15,17 @@ def normalize_file_permissions(st_mode):
         new_mode |= 0o111  # Executable: 644 -> 755
 
     return new_mode
+
+
+def escape_version(version):
+    """
+    Escaped version in wheel filename. Doesn't exactly follow
+    the escaping specification in :pep:`427#escaping-and-unicode`
+    because this conflicts with :pep:`440#local-version-identifiers`.
+    """
+    return re.sub(r"[^\w\d.+]+", "_", version, flags=re.UNICODE)
+
+
+def escape_name(name):
+    """Escaped wheel name as specified in :pep:`427#escaping-and-unicode`."""
+    return re.sub(r"[^\w\d.]+", "_", name, flags=re.UNICODE)

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -7,6 +7,7 @@ from clikit.io import NullIO
 
 from poetry.factory import Factory
 from poetry.masonry.builders import WheelBuilder
+from poetry.masonry.publishing.uploader import Uploader
 from poetry.utils._compat import Path
 from poetry.utils.env import NullEnv
 
@@ -64,7 +65,8 @@ def test_wheel_prerelease():
 
 def test_wheel_localversionlabel():
     module_path = fixtures_dir / "localversionlabel"
-    WheelBuilder.make(Factory().create_poetry(module_path), NullEnv(), NullIO())
+    project = Factory().create_poetry(module_path)
+    WheelBuilder.make(project, NullEnv(), NullIO())
     local_version_string = "localversionlabel-0.1b1+gitbranch.buildno.1"
     whl = module_path / "dist" / (local_version_string + "-py2.py3-none-any.whl")
 
@@ -72,6 +74,9 @@ def test_wheel_localversionlabel():
 
     with zipfile.ZipFile(str(whl)) as z:
         assert local_version_string + ".dist-info/METADATA" in z.namelist()
+
+    uploader = Uploader(project, NullIO())
+    assert whl in uploader.files
 
 
 def test_wheel_package_src():


### PR DESCRIPTION
This is a follow-up of #950 that allows publishing of wheels with local version identifier. Many thanks in advance for reviewing!

- [x] ~~Added **tests** for changed code.~~ Extended existing ones instead of adding dupes.
- [ ] ~~Updated **documentation** for changed code.~~ Same reason as in #950.