### PR TITLE
docs: Specify Python versions using double pipe

### DIFF
--- a/docs/docs/versions.md
+++ b/docs/docs/versions.md
@@ -126,7 +126,7 @@ pathlib2 = { version = "^2.2", python = "~2.7" }
 
 ```toml
 [tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", python = ["~2.7", "^3.2"] }
+pathlib2 = { version = "^2.2", python = "~2.7 || ^3.2" }
 ```
 
 


### PR DESCRIPTION
* Fix specification of Python versions for dependencies using double
  pipe (`||`) instead of using an array which leads to confusion (see for
  instance https://github.com/sdispater/poetry/issues/847).

* Fixes #847

Signed-off-by: mr.Shu <mr@shu.io>

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
