### PR TITLE
fix #686 encode credentials in install case

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -55,8 +55,8 @@ class PipInstaller(BaseInstaller):
             if auth:
                 index_url = "{scheme}://{username}:{password}@{netloc}{path}".format(
                     scheme=parsed.scheme,
-                    username=auth[0],
-                    password=auth[1],
+                    username=urlparse.quote(auth[0]),
+                    password=urlparse.quote(auth[1]),
                     netloc=parsed.netloc,
                     path=parsed.path,
                 )


### PR DESCRIPTION
Quick fix for #686 
This PR just fixes the install code path as the other one seems to forward the credentials to other components that should properly generate their own url.
