### PR TITLE
Fixes error messages that point to list items

### DIFF
--- a/poetry/json/__init__.py
+++ b/poetry/json/__init__.py
@@ -31,7 +31,9 @@ def validate_object(obj, schema_name):  # type: (dict, str) -> List[str]
     for error in validation_errors:
         message = error.message
         if error.path:
-            message = "[{}] {}".format(".".join(error.path), message)
+            message = "[{}] {}".format(
+                ".".join(str(x) for x in error.absolute_path), message
+            )
 
         errors.append(message)
 


### PR DESCRIPTION
poetry printed a misleading error message when the error stemmed from an item in a field. i didn't add a test because i wasn't able to spot an error messaging related that would exist.