### PR TITLE
Fix empty marker issues

### DIFF
--- a/poetry/packages/__init__.py
+++ b/poetry/packages/__init__.py
@@ -102,7 +102,10 @@ def dependency_from_pep_508(name):
             for op, version in or_:
                 # Expand python version
                 if op == "==":
-                    version = "~" + version
+                    if "*" in version:
+                        version = "==" + version
+                    else:
+                        version = "~" + version
                     op = ""
                 elif op == "!=":
                     version += ".*"

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -340,7 +340,7 @@ class Package(object):
 
         name = "{} (=={})".format(self._name, self._version)
 
-        if not self.marker.is_any():
+        if not self.marker.is_any() and not self.marker.is_empty():
             name += " ; {}".format(str(self.marker))
 
         return dependency_from_pep_508(name)

--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -162,6 +162,6 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
             return version
 
     if constraint == "<empty>":
-        return VersionRange()
+        return EmptyConstraint()
 
     raise ValueError("Could not parse version constraint: {}".format(constraint))

--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -161,4 +161,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         else:
             return version
 
+    if constraint == "<empty>":
+        return VersionRange()
+
     raise ValueError("Could not parse version constraint: {}".format(constraint))

--- a/poetry/semver/empty_constraint.py
+++ b/poetry/semver/empty_constraint.py
@@ -28,3 +28,6 @@ class EmptyConstraint(VersionConstraint):
 
     def __str__(self):
         return "<empty>"
+
+    def __eq__(self, other):
+        return other.is_empty()

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -169,3 +169,10 @@ def test_dependency_from_pep_508_with_not_in_op_marker():
     assert (
         str(dep.marker) == 'python_version not in "3.0,3.1,3.2" and extra == "export"'
     )
+
+
+def test_dependency_from_pep_508_with_python_version_wildcard():
+    name = 'requests; python_version == "2.7.*"'
+    dep = dependency_from_pep_508(name)
+    assert dep.name == "requests"
+    assert str(dep.python_versions) == "==2.7.*"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from poetry.packages import Package
+from poetry.version.markers import EmptyMarker
 
 
 def test_package_authors():
@@ -14,3 +15,11 @@ def test_package_authors():
     package.authors.insert(0, "John Doe")
     assert package.author_name == "John Doe"
     assert package.author_email is None
+
+
+def test_package_empty_marker():
+    package = Package("foo", "0.1.0")
+    package.marker = EmptyMarker()
+
+    dep = package.to_dependency()
+    assert dep.python_versions == "*"

--- a/tests/semver/test_main.py
+++ b/tests/semver/test_main.py
@@ -1,6 +1,7 @@
 import pytest
 
 from poetry.semver import parse_constraint
+from poetry.semver import EmptyConstraint
 from poetry.semver import Version
 from poetry.semver import VersionRange
 from poetry.semver import VersionUnion
@@ -25,7 +26,7 @@ from poetry.semver import VersionUnion
         ("1.2.3b5", Version(1, 2, 3, pre="b5")),
         (">= 1.2.3", VersionRange(min=Version(1, 2, 3), include_min=True)),
         (">dev", VersionRange(min=Version(0, 0, pre="dev"))),  # Issue 206
-        ("<empty>", VersionRange()),
+        ("<empty>", EmptyConstraint()),
     ],
 )
 def test_parse_constraint(input, constraint):

--- a/tests/semver/test_main.py
+++ b/tests/semver/test_main.py
@@ -25,6 +25,7 @@ from poetry.semver import VersionUnion
         ("1.2.3b5", Version(1, 2, 3, pre="b5")),
         (">= 1.2.3", VersionRange(min=Version(1, 2, 3), include_min=True)),
         (">dev", VersionRange(min=Version(0, 0, pre="dev"))),  # Issue 206
+        ("<empty>", VersionRange()),
     ],
 )
 def test_parse_constraint(input, constraint):


### PR DESCRIPTION
Updated version of #1230 (I didn't realize rebasing would make it so I couldn't re-open the PR)

This PR addresses a family of related problems we were seeing when depending on particular packages.

Based on what I saw in the codebase, there is a concept of an "empty" marker. However there were a few places in the code that didn't handle these empty markers properly.

Here's an example `pyproject.toml` where we were hitting the issue:

```toml
[tool.poetry]
name = "example_project"
version = "1.0.0"
description = ""
authors = [""]

[tool.poetry.dependencies]
python = ">=2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"

[tool.poetry.dev-dependencies]
pytest = "^3.0.6"
pylama = "^7.6"
pylint = { version = "^2.2", python = ">= 3.5" }
pytest-cov = "^2.6"
black = { version = "18.9b0", python = ">= 3.6" }
sphinx = { version = "^2.0", python = ">= 3.5" }

[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"
```

Doing `poetry install` once to generate the `poetry.lock` and then running `poetry install` again will reproduce the issue:

```
$ poetry install
Installing dependencies from lock file

[InvalidRequirement]
Invalid requirement, parse error at "'; <empty'"

install [--no-dev] [--dry-run] [-E|--extras EXTRAS] [--develop DEVELOP]
```
Also I believe this fixes #978 which seems to be hitting a similar problem.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
