### PR TITLE
Fix for "render takes 2 arguments" error.

### DIFF
--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -3,7 +3,6 @@ import sys
 
 from .env_command import EnvCommand
 
-
 class ShowCommand(EnvCommand):
     """
     Shows information about packages.
@@ -76,7 +75,7 @@ lists all packages available."""
             ]
 
             table.add_rows(rows)
-            table.render()
+            table.render(self.io)
 
             if pkg.requires:
                 self.line("")


### PR DESCRIPTION
Fixes output like:
```
poetry show -l pytest

[TypeError]
render() takes at least 2 arguments (1 given)
```

Original line may have been for a future version of cleo.