### PR TITLE
Improve run command

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -27,18 +27,16 @@ class RunCommand(EnvCommand):
 
         src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src() else ""
 
-        cmd = ["python", "-c"]
+        cmd = ["-c"]
 
         cmd += [
-            '"import sys; '
+            "import sys; "
             "from importlib import import_module; "
             "sys.argv = {!r}; {}"
-            "import_module('{}').{}()\"".format(
-                args, src_in_sys_path, module, callable_
-            )
+            "import_module('{}').{}()".format(args, src_in_sys_path, module, callable_)
         ]
 
-        return self.env.run(*cmd, shell=True, call=True)
+        return self.env.execute("python", *cmd)
 
     @property
     def _module(self):

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -389,10 +389,12 @@ class Env(object):
 
         return decode(output)
 
-    def execute(self, bin, *args, **kwargs):
+    def execute(self, bin, *args):
         bin = self._bin(bin)
-
-        return subprocess.call([bin] + list(args), **kwargs)
+        if os.name == "nt":
+            return subprocess.call([bin] + list(args))
+        else:
+            os.execvp(bin, [bin] + list(args))
 
     def is_venv(self):  # type: () -> bool
         raise NotImplementedError()
@@ -538,7 +540,7 @@ class VirtualEnv(Env):
 
             return super(VirtualEnv, self).run(bin, *args, **kwargs)
 
-    def execute(self, bin, *args, **kwargs):
+    def execute(self, bin, *args):
         with self.temp_environ():
             os.environ["PATH"] = self._updated_path()
             os.environ["VIRTUAL_ENV"] = str(self._path)
@@ -546,7 +548,7 @@ class VirtualEnv(Env):
             self.unset_env("PYTHONHOME")
             self.unset_env("__PYVENV_LAUNCHER__")
 
-            return super(VirtualEnv, self).execute(bin, *args, **kwargs)
+            return super(VirtualEnv, self).execute(bin, *args)
 
     @contextmanager
     def temp_environ(self):


### PR DESCRIPTION
Currently "poetry run" command uses subprocess.call for starting
programs and scripts. This approach has a problem --- signals like
Ctrl-C are caught by poetry process itself and not by the process the
user has run.

This can be observed this way: run "poetry run python" and press Ctrl-C.
Normally Python interpreter will catch the signal and print
"KeyboardInterrupt" exception, continuing execution normally. But when
run by poetry, it exits immediately. This behavior is rather annoying,
as one has to restart interpreter after accidentially doing Ctrl-C.
Moreover, after python exits, it leaves terminal in a broken state,
requiring the user to use "reset" or similar command.

This commit fixes this behavior by using "os.execvp" instead of
subprocess. This replaces poetry process directly with target process,
eliminating an intermediate process.

This approach is used in other products like Pipenv and Haskell's build
system stack. See these links for examples and more info:

- https://github.com/pypa/pipenv/blob/master/pipenv/core.py#L2462
- https://github.com/commercialhaskell/stack/issues/527
- https://hackage.haskell.org/package/rio-0.1.12.0/docs/RIO-Process.html#v:exec

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

# Notes

- I'm unsure if it makes sense to add tests for this functionality. Right now there are no tests for `run` command in poetry.
- Windows runs the old way, this issue seems not to be present there.
- Also, it seems that nothing has to be added to the docs, as this a simple fix.