### PR TITLE
Detect Conda when looking for a virtual env

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -286,7 +286,13 @@ class EnvManager(object):
                 python_minor = env["minor"]
 
         # Check if we are inside a virtualenv or not
-        in_venv = os.environ.get("VIRTUAL_ENV") is not None
+        # Conda sets CONDA_PREFIX in its envs, see
+        # https://github.com/conda/conda/issues/2764
+        env_prefix = os.environ.get("VIRTUAL_ENV", os.environ.get("CONDA_PREFIX"))
+        conda_env_name = os.environ.get("CONDA_DEFAULT_ENV")
+        # It's probably not a good idea to pollute Conda's global "base" env, since
+        # most users have it activated all the time.
+        in_venv = env_prefix is not None and conda_env_name != "base"
 
         if not in_venv or env is not None:
             # Checking if a local virtualenv exists
@@ -315,8 +321,8 @@ class EnvManager(object):
 
             return VirtualEnv(venv)
 
-        if os.environ.get("VIRTUAL_ENV") is not None:
-            prefix = Path(os.environ["VIRTUAL_ENV"])
+        if env_prefix is not None:
+            prefix = Path(env_prefix)
             base_prefix = None
         else:
             prefix = Path(sys.prefix)


### PR DESCRIPTION
Currently Poetry will detect that it is running in a usual virtual env
created with "python -m venv" and will not create an additional env.

This commit extends this logic to Conda, which uses different
environment variables to indicate running in a virtual env.

Conda's "base" env is treated specially to avoid polluting global
namespace.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
