### PR TITLE
Add support for Python 3.8

### DIFF
--- a/make-linux-release.sh
+++ b/make-linux-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PYTHON_VERSIONS="cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m"
+PYTHON_VERSIONS="cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38m"
 
 cd /io
 /opt/python/cp37-cp37m/bin/pip install poetry -U
@@ -10,5 +10,6 @@ cd /io
     -P "3.4:/opt/python/cp34-cp34m/bin/python" \
     -P "3.5:/opt/python/cp35-cp35m/bin/python" \
     -P "3.6:/opt/python/cp36-cp36m/bin/python" \
-    -P "3.7:/opt/python/cp37-cp37m/bin/python"
+    -P "3.7:/opt/python/cp37-cp37m/bin/python" \
+    -P "3.8:/opt/python/cp38-cp38m/bin/python"
 cd -

--- a/sonnet
+++ b/sonnet
@@ -28,6 +28,7 @@ class MakeReleaseCommand(Command):
         "3.5": "python3.5",
         "3.6": "python3.6",
         "3.7": "python3.7",
+        "3.8": "python3.8",
     }
 
     def handle(self):
@@ -46,7 +47,7 @@ class MakeReleaseCommand(Command):
         self.check_system(pythons)
 
         from poetry import __version__
-        from poetry.poetry import Poetry
+        from poetry.factory import Factory
         from poetry.puzzle import Solver
         from poetry.repositories.pool import Pool
         from poetry.repositories.repository import Repository
@@ -59,7 +60,7 @@ class MakeReleaseCommand(Command):
         from poetry.utils.helpers import temporary_directory
         from poetry.vcs import get_vcs
 
-        project = Poetry.create(Path.cwd())
+        project = Factory().create_poetry(Path.cwd())
         package = project.package
         del package.dev_requires[:]
 

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -79,7 +79,7 @@ def test_wheel_c_extension():
 Wheel-Version: 1.0
 Generator: poetry {}
 Root-Is-Purelib: false
-Tag: cp[23]\\d-cp[23]\\dmu?-.+
+Tag: cp[23]\\d-cp[23]\\dm?u?-.+
 $""".format(
                     __version__
                 ),
@@ -136,7 +136,7 @@ def test_wheel_c_extension_src_layout():
 Wheel-Version: 1.0
 Generator: poetry {}
 Root-Is-Purelib: false
-Tag: cp[23]\\d-cp[23]\\dmu?-.+
+Tag: cp[23]\\d-cp[23]\\dm?u?-.+
 $""".format(
                     __version__
                 ),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py34, py35, py36, py37, py38
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
# Pull Request Check List

This PR add support for Python 3.8 in order to build and publish releases that are compatible with Python 3.8 when the stable is released.

The only thing missing right now to make a compatible release is an up-to-date Docker image of [manylinux](https://github.com/pypa/manylinux). Hopefully this will happen soon and the `1.0.0b2` version can be released next week.
