### PR TITLE
* check if relative filename is in excluded file list

### DIFF
--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -153,7 +153,7 @@ class WheelBuilder(Builder):
                 else:
                     rel_file = file.relative_to(self._path)
 
-                if file in excluded:
+                if str(rel_file) in excluded:
                     continue
 
                 if file.suffix == ".pyc":
@@ -198,10 +198,6 @@ class WheelBuilder(Builder):
                 f.write("{},sha256={},{}\n".format(path, hash, size))
             # RECORD itself is recorded with no hash or size
             f.write(self.dist_info + "/RECORD,,\n")
-
-    def find_excluded_files(self):  # type: () -> Set
-        # Checking VCS
-        return set()
 
     @property
     def dist_info(self):  # type: () -> str


### PR DESCRIPTION
This is a fix for #1384 .

The method `find_excluded_files` in `wheel.py` unnecessarily overwrite the original method inherited from `Builder` by returning just an empty set. I removed this method.

Comparison, if the file is contained in  `excluded`, was done with the absolute filename while the filenames in `excluded` are relative filepath name. Also one have to take care about the types. While `rel_file` is of type `Path` the names in the `excluded` set are `str`.