### PR TITLE
provider:search_for_directory - set package.root_dir

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -277,6 +277,9 @@ class Provider:
 
         package.source_url = dependency.path.as_posix()
 
+        if dependency.base != None:
+            package.root_dir = dependency.base.as_posix()
+
         for extra in dependency.extras:
             if extra in package.extras:
                 for dep in package.extras[extra]:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -175,6 +175,46 @@ def test_search_for_directory_setup_egg_info_with_extras(provider):
     }
 
 
+@pytest.mark.parametrize("directory", ["demo", "non-canonical-name"])
+def test_search_for_directory_setup_with_base(provider, directory):
+    dependency = DirectoryDependency(
+        "demo",
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "git"
+        / "github.com"
+        / "demo"
+        / directory,
+        base=Path(__file__).parent.parent
+        / "fixtures"
+        / "git"
+        / "github.com"
+        / "demo"
+        / directory,
+    )
+
+    package = provider.search_for_directory(dependency)[0]
+
+    assert package.name == "demo"
+    assert package.version.text == "0.1.2"
+    assert package.requires == [get_dependency("pendulum", ">=1.4.4")]
+    assert package.extras == {
+        "foo": [get_dependency("cleo")],
+        "bar": [get_dependency("tomlkit")],
+    }
+    assert (
+        package.root_dir
+        == (
+            Path(__file__).parent.parent
+            / "fixtures"
+            / "git"
+            / "github.com"
+            / "demo"
+            / directory
+        ).as_posix()
+    )
+
+
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())


### PR DESCRIPTION
-- `package` from provider.py:search_for_directory
   is missing root_dir value. This fixes the problem.
-- fix https://github.com/sdispater/poetry/issues/1455

I hope I am not missing anything. The `root_dir` is eventually used here https://github.com/sdispater/poetry/blob/21ed84ed9b422a049c3e2d6b639d9de53ab60dc6/poetry/installation/pip_installer.py#L128 to build the path to the local package.