### PR TITLE
Fix #1417 - poetry env commands are not using correct package name

### DIFF
--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -14,7 +14,9 @@ class EnvInfoCommand(Command):
         from poetry.utils.env import EnvManager
 
         poetry = self.poetry
-        env = EnvManager(poetry.config).get(cwd=poetry.file.parent)
+        env = EnvManager(poetry.config).get(
+            cwd=poetry.file.parent, name=poetry.package.name
+        )
 
         if self.option("path"):
             if not env.is_venv():

--- a/poetry/console/commands/env/list.py
+++ b/poetry/console/commands/env/list.py
@@ -15,9 +15,11 @@ class EnvListCommand(Command):
 
         poetry = self.poetry
         manager = EnvManager(poetry.config)
-        current_env = manager.get(self.poetry.file.parent)
+        current_env = manager.get(
+            self.poetry.file.parent, name=self.poetry.package.name
+        )
 
-        for venv in manager.list(self.poetry.file.parent):
+        for venv in manager.list(self.poetry.file.parent, self.poetry.package.name):
             name = venv.path.name
             if self.option("full-path"):
                 name = str(venv.path)

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -17,6 +17,8 @@ class EnvRemoveCommand(Command):
 
         poetry = self.poetry
         manager = EnvManager(poetry.config)
-        venv = manager.remove(self.argument("python"), poetry.file.parent)
+        venv = manager.remove(
+            self.argument("python"), poetry.file.parent, poetry.package.name
+        )
 
         self.line("Deleted virtualenv: <comment>{}</comment>".format(venv.path))

--- a/poetry/console/commands/env/use.py
+++ b/poetry/console/commands/env/use.py
@@ -17,10 +17,12 @@ class EnvUseCommand(Command):
         manager = EnvManager(poetry.config)
 
         if self.argument("python") == "system":
-            manager.deactivate(poetry.file.parent, self._io)
+            manager.deactivate(poetry.file.parent, self._io, poetry.package.name)
 
             return
 
-        env = manager.activate(self.argument("python"), poetry.file.parent, self._io)
+        env = manager.activate(
+            self.argument("python"), poetry.file.parent, self._io, poetry.package.name
+        )
 
         self.line("Using virtualenv: <comment>{}</>".format(env.path))

--- a/tests/console/commands/env/test_list.py
+++ b/tests/console/commands/env/test_list.py
@@ -11,7 +11,7 @@ def test_none_activated(app, tmp_dir):
     app.poetry.config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
@@ -34,7 +34,7 @@ def test_activated(app, tmp_dir):
     app.poetry.config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -11,7 +11,7 @@ def test_remove_by_python_version(app, tmp_dir, mocker):
     app.poetry.config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
@@ -39,7 +39,7 @@ def test_remove_by_name(app, tmp_dir):
     app.poetry.config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -57,7 +57,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(app, tmp_dir, m
     tester.execute("3.7")
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
 
     m.assert_called_with(
@@ -88,7 +88,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
 
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     current_python = sys.version_info[:3]
     python_minor = ".".join(str(v) for v in current_python[:2])
@@ -128,9 +128,8 @@ def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
     app, tmp_dir, mocker
 ):
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
-
     venv_name = EnvManager.generate_env_name(
-        "simple_project", str(app.poetry.file.parent)
+        "simple-project", str(app.poetry.file.parent)
     )
     current_python = sys.version_info[:3]
     python_minor = ".".join(str(v) for v in current_python[:2])


### PR DESCRIPTION
As outlined in issues #1417 and #1425, the `poetry env` commands are behaving unexpectedly when the package name specified in pyproject.toml differs from the directory name of the package. 

This PR tries to fix this behavior.

I changed the current tests to use the package name instead of the directory name, I assume that's good enough for this issue. If more testing is needed, let me know.