### PR TITLE
Fix typo + reformat help in LockCommand

### DIFF
--- a/poetry/console/commands/lock.py
+++ b/poetry/console/commands/lock.py
@@ -6,8 +6,10 @@ class LockCommand(EnvCommand):
     name = "lock"
     description = "Locks the project dependencies."
 
-    help = """The <info>lock</info> command reads the <comment>pyproject.toml</> file from
-the current directory, processes it, and locks the dependencies in the <comment>poetry.lock</> file.
+    help = """
+The <info>lock</info> command reads the <comment>pyproject.toml</> file from the
+current directory, processes it, and locks the dependencies in the <comment>poetry.lock</>
+file.
 
 <info>poetry lock</info>
 """

--- a/poetry/console/commands/lock.py
+++ b/poetry/console/commands/lock.py
@@ -7,7 +7,7 @@ class LockCommand(EnvCommand):
     description = "Locks the project dependencies."
 
     help = """The <info>lock</info> command reads the <comment>pyproject.toml</> file from
-the current directory, processes it, and locks the depdencies in the <comment>poetry.lock</> file.
+the current directory, processes it, and locks the dependencies in the <comment>poetry.lock</> file.
 
 <info>poetry lock</info>
 """


### PR DESCRIPTION
Nothing at all major here noticed a typo and that the help command was wrapping weirdly.