### PR TITLE
define clikit as a direct dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1206,7 +1206,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "217a3a1a7edea0cbedd6e5dfffe1aface3e96d17b947e86d7138a1b233ae3bd7"
+content-hash = "402f356e484839dbb4361c25f986325cc08f1d441d777a15950cb28ce71ac005"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 # Requirements
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"
+clikit = "^0.4.0"
 cleo = "^0.7.6"
 requests = "^2.18"
 cachy = "^0.3.0"
@@ -54,7 +55,6 @@ keyring = [
 ]
 # Use subprocess32 for Python 2.7 and 3.4
 subprocess32 = { version = "^3.5", python = "~2.7 || ~3.4" }
-clikit = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ keyring = [
 ]
 # Use subprocess32 for Python 2.7 and 3.4
 subprocess32 = { version = "^3.5", python = "~2.7 || ~3.4" }
+clikit = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.1"


### PR DESCRIPTION
this is not a fix for https://github.com/sdispater/poetry/issues/1497 but it's the right thing to do, and will avoid similar problems in the future. in general, the rule of thumb is that if you are directly importing something, then it needs to be specified as a direct dependency, and not rely on transitivity to be there (because it also might introduce silent breaking changes, see #1497)