### PR TITLE
Make Poetry respect XDG variables on macOS

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -4,11 +4,11 @@ Poetry can be configured via the `config` command ([see more about its usage her
 or directly in the `config.toml` file that will be automatically be created when you first run that command.
 This file can typically be found in one of the following directories:
 
-- macOS:   `~/Library/Application Support/pypoetry`
 - Windows: `C:\Users\<username>\AppData\Roaming\pypoetry`
-
-For Unix, we follow the XDG spec and support `$XDG_CONFIG_HOME`.
-That means, by default `~/.config/pypoetry`.
+- macOS:   If you have the `$XDG_CONFIG_HOME` set, Poetry will follow the XDG
+           spec, otherwise `~/Library/Application Support/pypoetry` is used
+- Unix:    follow the XDG spec and support `$XDG_CONFIG_HOME`. That means, by
+           default `~/.config/pypoetry`.
 
 ## Local configuration
 
@@ -98,9 +98,11 @@ The path to the cache directory used by Poetry.
 
 Defaults to one of the following directories:
 
-- macOS:   `~/Library/Caches/pypoetry`
 - Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`
-- Unix:    `~/.cache/pypoetry/virtualenvs`
+- macOS:   If you have the `$XDG_CACHE_HOME` set, Poetry will follow the XDG
+           spec, otherwise `~/Library/Caches/pypoetry` is used
+- Unix:    follow the XDG spec and support `$XDG_CACHE_HOME`. That means, by
+           default `~/.cache/pypoetry`.
 
 ### `virtualenvs.create`: boolean
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,7 +26,13 @@ curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.p
     Python version and use it to [create virtualenvs](/docs/basic-usage/#poetry-and-virtualenvs) accordingly.
 
 The installer installs the `poetry` tool to Poetry's `bin` directory.
-On Unix it is located at `$HOME/.poetry/bin` and on Windows at `%USERPROFILE%\.poetry\bin`.
+This directory can be found in one of the following locations:
+
+1. The value of environment variable `$POETRY_HOME/bin`;
+2. On `$XDG_PACKAGE_HOME/poetry/bin`
+3. On Unix `$HOME/.poetry/bin` and on Windows at `%USERPROFILE%\.poetry\bin`.
+
+Whichever can be found first in this order.
 
 This directory will be in your `$PATH` environment variable,
 which means you can run them from the shell without further configuration.

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -187,7 +187,13 @@ def expanduser(path):
 
 
 HOME = expanduser("~")
-POETRY_HOME = os.environ.get("POETRY_HOME") or os.path.join(HOME, ".poetry")
+POETRY_HOME = os.getenv("POETRY_HOME")
+if not POETRY_HOME:
+    POETRY_HOME = os.getenv("XDG_PACKAGE_HOME")
+    if POETRY_HOME:
+        POETRY_HOME = os.path.join(POETRY_HOME, "poetry")
+    else:
+        POETRY_HOME = os.path.join(HOME, ".poetry")
 POETRY_BIN = os.path.join(POETRY_HOME, "bin")
 POETRY_ENV = os.path.join(POETRY_HOME, "env")
 POETRY_LIB = os.path.join(POETRY_HOME, "lib")

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -33,12 +33,9 @@ class SelfUpdateCommand(Command):
 
     @property
     def home(self):
-        from poetry.utils._compat import Path
-        from poetry.utils.appdirs import expanduser
+        from poetry.utils.appdirs import poetry_home_dir
 
-        home = Path(expanduser("~"))
-
-        return home / ".poetry"
+        return poetry_home_dir()
 
     @property
     def lib(self):

--- a/tests/utils/test_appdirs.py
+++ b/tests/utils/test_appdirs.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from os import path
+
+import pytest
+
+from poetry.utils import appdirs
+
+windows = pytest.mark.skipif(
+    not (sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")),
+    reason="tests that check Windows only behavior",
+)
+
+macos = pytest.mark.skipif(
+    sys.platform != "darwin", reason="tests that check macOS only behavior"
+)
+
+unix = pytest.mark.skipif(
+    sys.platform.startswith("win")
+    or (sys.platform == "cli" and os.name == "nt")
+    or sys.platform == "darwin",
+    reason="tests that check Unix type behavior",
+)
+
+macos_and_unix = pytest.mark.skipif(
+    sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt"),
+    reason="tests that check either Unix or macOS behavior",
+)
+
+
+@macos_and_unix
+def test_poetry_home_defined_by_env_var():
+    crazy_dir = path.join(os.environ["HOME"], "my_crazy_dir")
+    os.environ["POETRY_HOME"] = crazy_dir
+    assert appdirs.poetry_home_dir() == crazy_dir
+    del os.environ["POETRY_HOME"]
+
+
+@macos_and_unix
+def test_poetry_home_defined_by_xdg():
+    xdg_package_home = path.join(os.environ["HOME"], ".local", "opt")
+    poetry_home = path.join(xdg_package_home, "poetry")
+    os.environ["XDG_PACKAGE_HOME"] = xdg_package_home
+    assert appdirs.poetry_home_dir() == poetry_home
+    del os.environ["XDG_PACKAGE_HOME"]
+
+
+@macos_and_unix
+def test_poetry_home_fallback_default():
+    poetry_home = path.join(os.environ["HOME"], ".poetry")
+    assert appdirs.poetry_home_dir() == poetry_home
+
+
+@macos_and_unix
+def test_user_cache_dir_xdg_set():
+    xdg_cache_home = path.join(os.environ["HOME"], ".local", "var", "cache")
+    poetry_cache = path.join(xdg_cache_home, "poetry")
+    os.environ["XDG_CACHE_HOME"] = xdg_cache_home
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+    del os.environ["XDG_CACHE_HOME"]
+
+
+@macos
+def test_user_cache_dir_macos_default():
+    poetry_cache = path.join(appdirs.expanduser("~/Library/Caches"), "poetry")
+    if "XDG_CACHE_HOME" in os.environ:
+        del os.environ["XDG_CACHE_HOME"]
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+
+
+@unix
+def test_user_cache_dir_unix_default():
+    poetry_cache = path.join(appdirs.expanduser("~/.cache"), "poetry")
+    if "XDG_CACHE_HOME" in os.environ:
+        del os.environ["XDG_CACHE_HOME"]
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+
+
+@macos_and_unix
+def test_user_data_dir_xdg_set():
+    xdg_data_home = path.join(os.environ["HOME"], ".local", "crazy_path", "data")
+    poetry_data = path.join(xdg_data_home, "poetry")
+    os.environ["XDG_DATA_HOME"] = xdg_data_home
+    assert appdirs.user_data_dir("poetry") == poetry_data
+    del os.environ["XDG_DATA_HOME"]
+
+
+@macos
+def test_user_data_dir_macos_default():
+    poetry_data = path.join(
+        appdirs.expanduser("~/Library/Application Support"), "poetry"
+    )
+    if "XDG_DATA_HOME" in os.environ:
+        del os.environ["XDG_DATA_HOME"]
+    assert appdirs.user_data_dir("poetry") == poetry_data
+
+
+@unix
+def test_user_data_dir_unix_default():
+    poetry_data = path.join(appdirs.expanduser("~/.local/share"), "poetry")
+    if "XDG_DATA_HOME" in os.environ:
+        del os.environ["XDG_DATA_HOME"]
+    assert appdirs.user_data_dir("poetry") == poetry_data
+
+
+@macos_and_unix
+def test_user_config_dir_xdg_set():
+    xdg_config_home = path.join(os.environ["HOME"], ".local", "crazy_path", "data")
+    poetry_config = path.join(xdg_config_home, "poetry")
+    os.environ["XDG_CONFIG_HOME"] = xdg_config_home
+    assert appdirs.user_config_dir("poetry") == poetry_config
+    del os.environ["XDG_CONFIG_HOME"]
+
+
+@macos
+def test_user_config_dir_macos_default():
+    poetry_data = path.join(
+        appdirs.expanduser("~/Library/Application Support"), "poetry"
+    )
+    if "XDG_CONFIG_HOME" in os.environ:
+        del os.environ["XDG_CONFIG_HOME"]
+    assert appdirs.user_config_dir("poetry") == poetry_data
+
+
+@unix
+def test_user_config_dir_unix_default():
+    poetry_data = path.join(appdirs.expanduser("~/.config"), "poetry")
+    if "XDG_CONFIG_HOME" in os.environ:
+        del os.environ["XDG_CONFIG_HOME"]
+    assert appdirs.user_config_dir("poetry") == poetry_data
+
+
+@macos
+def test_site_config_dirs_xdg_set_macos():
+    site_config_dirs = [
+        appdirs.expanduser("~/.local/config.d"),
+        appdirs.expanduser("~/.config/others.d"),
+    ]
+    os.environ["XDG_CONFIG_DIRS"] = os.pathsep.join(site_config_dirs)
+
+    for expected, actual in zip(
+        [path.join(x, "poetry") for x in site_config_dirs],
+        appdirs.site_config_dirs("poetry"),
+    ):
+        assert expected == actual
+
+    del os.environ["XDG_CONFIG_DIRS"]
+
+
+@macos
+def test_site_config_dirs_macos_default():
+    site_config_dirs = [
+        path.join(appdirs.expanduser("~/Library/Application Support"), "poetry")
+    ]
+    if "XDG_CONFIG_DIRS" in os.environ:
+        del os.environ["XDG_CONFIG_DIRS"]
+    for expected, actual in zip(site_config_dirs, appdirs.site_config_dirs("poetry")):
+        assert expected == actual
+
+
+@unix
+def test_site_config_dirs_xdg_set_unix():
+    site_config_dirs = [
+        appdirs.expanduser("~/.local/config.d"),
+        appdirs.expanduser("~/.config/others.d"),
+    ]
+    os.environ["XDG_CONFIG_DIRS"] = os.pathsep.join(site_config_dirs)
+    site_config_dirs.append("/etc")
+
+    for expected, actual in zip(
+        [path.join(x, "poetry") for x in site_config_dirs],
+        appdirs.site_config_dirs("poetry"),
+    ):
+        assert expected == actual
+
+    del os.environ["XDG_CONFIG_DIRS"]
+
+
+@unix
+def test_site_config_dirs_unix_default():
+    site_config_dirs = ["/etc/xdg/poetry", "/etc/poetry"]
+    if "XDG_CONFIG_DIRS" in os.environ:
+        del os.environ["XDG_CONFIG_DIRS"]
+    for expected, actual in zip(site_config_dirs, appdirs.site_config_dirs("poetry")):
+        assert expected == actual


### PR DESCRIPTION
## Changes Description

Since macOS is a Unix system, there is no reason to not allow Poetry to
use the XDG variables to install and maintain itself.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
