### PR TITLE
add failing test case: multiple constraints on root devDeps

### DIFF
--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1570,3 +1570,21 @@ def test_multiple_constraints_on_root(package, solver, repo):
         ops,
         [{"job": "install", "package": foo15}, {"job": "install", "package": foo25}],
     )
+
+
+def test_multiple_constraints_on_root_dev(package, solver, repo):
+    package.add_dependency("foo", {"version": "^1.0", "python": "^2.7"}, category="dev")
+    package.add_dependency("foo", {"version": "^2.0", "python": "^3.7"}, category="dev")
+
+    foo15 = get_package("foo", "1.5.0")
+    foo25 = get_package("foo", "2.5.0")
+
+    repo.add_package(foo15)
+    repo.add_package(foo25)
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops,
+        [{"job": "install", "package": foo15}, {"job": "install", "package": foo25}],
+    )


### PR DESCRIPTION
- SolverProblemError occurs with multiple constraints that do not
  intersect in dev-dependencies
  - this was fixed for main dependencies in 0.12.11 and 1.0.0a2, but
    still occurs for devDeps
    - moving devDeps to main makes the error go away

See my comment in https://github.com/sdispater/poetry/issues/666#issuecomment-531100022 as well as another confirming this occurs https://github.com/sdispater/poetry/issues/666#issuecomment-541338055 .
The failing test case puts this bug into a reproducible case and solidifies the existence of the bug.

I tried to fix the bug on my own, but couldn't figure out where it occurs / what's causing it. There's very little code that deviates between devDeps and main deps -- as far as I can tell, only where `category = "dev"` or `dev_requires` is used.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
