### PR TITLE
Set mtime on setup.py/PKG-INFO when building sdist

### DIFF
--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -2,6 +2,7 @@
 import os
 import re
 import tarfile
+import time
 
 from collections import defaultdict
 from copy import copy
@@ -83,12 +84,14 @@ class SdistBuilder(Builder):
             setup = self.build_setup()
             tar_info = tarfile.TarInfo(pjoin(tar_dir, "setup.py"))
             tar_info.size = len(setup)
+            tar_info.mtime = time.time()
             tar.addfile(tar_info, BytesIO(setup))
 
             pkg_info = self.build_pkg_info()
 
             tar_info = tarfile.TarInfo(pjoin(tar_dir, "PKG-INFO"))
             tar_info.size = len(pkg_info)
+            tar_info.mtime = time.time()
             tar.addfile(tar_info, BytesIO(pkg_info))
         finally:
             tar.close()

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -408,6 +408,9 @@ def test_default_with_excluded_data(mocker):
         assert "my-package-1.2.3/pyproject.toml" in names
         assert "my-package-1.2.3/setup.py" in names
         assert "my-package-1.2.3/PKG-INFO" in names
+        # all last modified times should be set to a valid timestamp
+        for tarinfo in tar.getmembers():
+            assert 0 < tarinfo.mtime
 
 
 def test_proper_python_requires_if_two_digits_precision_version_specified():


### PR DESCRIPTION
**Bug Fix**

Previously, the `mtime` of `setup.py` and `PKG-INFO` was the default value of 0, which showed that the files were last modified on Jan 1st 1970.

This created the following warning when using gnu tar:
`implausibly old time stamp 1970-01-01 01:00:00`

This commit sets the last modified time of `setup.py` and `PKG-INFO` to the time they are created, and tests that every file in the `sdist` `tar.gz` has a valid (i.e. greater than 0) `mtime`.

Fixes #670.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
