### PR TITLE
Bugfix:`find_best_candidate` sort order affects result

### DIFF
--- a/poetry/version/version_selector.py
+++ b/poetry/version/version_selector.py
@@ -35,8 +35,7 @@ class VersionSelector(object):
 
         dependency = Dependency(package_name, constraint)
 
-        # Select highest version if we have many
-        package = candidates[0]
+        package = None
         for candidate in candidates:
             if (
                 candidate.is_prerelease()
@@ -47,9 +46,11 @@ class VersionSelector(object):
                 continue
 
             # Select highest version of the two
-            if package.version < candidate.version:
+            if package is None or package.version < candidate.version:
                 package = candidate
 
+        if package is None:
+            return False
         return package
 
     def find_recommended_require_version(self, package):

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -379,6 +379,138 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
+def test_show_outdated_has_prerelease_but_not_allowed(app, poetry, installed, repo):
+    command = app.find("show")
+    tester = CommandTester(command)
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+    cachy_030dev = get_package("cachy", "0.3.0.dev123")
+    cachy_030dev.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+
+    # sorting isn't used, so this has to be the first element to
+    # replicate the issue in PR #1548
+    repo.add_package(cachy_030dev)
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    tester.execute("--outdated")
+
+    expected = """\
+cachy 0.1.0 0.2.0 Cachy package
+"""
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_show_outdated_has_prerelease_and_allowed(app, poetry, installed, repo):
+    command = app.find("show")
+    tester = CommandTester(command)
+
+    cachy_010dev = get_package("cachy", "0.1.0.dev1")
+    cachy_010dev.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+    cachy_030dev = get_package("cachy", "0.3.0.dev123")
+    cachy_030dev.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+
+    installed.add_package(cachy_010dev)
+    installed.add_package(pendulum_200)
+
+    # sorting isn't used, so this has to be the first element to
+    # replicate the issue in PR #1548
+    repo.add_package(cachy_030dev)
+    repo.add_package(cachy_010dev)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0.dev1",
+                    "description": "Cachy package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    tester.execute("--outdated")
+
+    expected = """\
+cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
+"""
+
+    assert expected == tester.io.fetch_output()
+
+
 def test_show_outdated_formatting(app, poetry, installed, repo):
     command = app.find("show")
     tester = CommandTester(command)


### PR DESCRIPTION
### Description
`find_best_candidate` picks the 0th element of the list as a default. Since this list includes both invalid and valid items, it's possible to return an invalid item. In this case it was returning a pre-release when pre-releases wren't allowed.

Since this is a bugfix, I did not update the documentation.

### Pull Request Check List
This is just a reminder about the most common mistakes. Please make sure that you tick all appropriate boxes. But please read our contribution guide at least once, it will save you unnecessary review cycles!

- [x] Added tests for changed code.
- [x] Updated documentation for changed code.
Note: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the develop branch. If it's a bug fix or only a documentation update, it should be based on the master branch.

If you have any questions to any of the points above, just submit and ask! This checklist is here to help you, not to deter you from contributing!