### PR TITLE
Fix allow-prerelease typo in deprecation message and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ toml = "^0.9"
 # Dependencies with extras
 requests = { version = "^2.13", extras = [ "security" ] }
 # Python specific dependencies with prereleases allowed
-pathlib2 = { version = "^2.2", python = "~2.7", allows-prereleases = true }
+pathlib2 = { version = "^2.2", python = "~2.7", allow-prereleases = true }
 # Git dependencies
 cleo = { git = "https://github.com/sdispater/cleo.git", branch = "master" }
 

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -298,7 +298,7 @@ class Factory:
                         result["warnings"].append(
                             'The "{}" dependency specifies '
                             'the "allows-prereleases" property, which is deprecated. '
-                            'Use "allow-preleases" instead.'.format(name)
+                            'Use "allow-prereleases" instead.'.format(name)
                         )
 
             # Checking for scripts with extras

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -279,7 +279,7 @@ class Package(object):
                 message = (
                     'The "{}" dependency specifies '
                     'the "allows-prereleases" property, which is deprecated. '
-                    'Use "allow-preleases" instead.'.format(name)
+                    'Use "allow-prereleases" instead.'.format(name)
                 )
                 warn(message, DeprecationWarning)
                 logger.warning(message)

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -36,14 +36,14 @@ def test_check_invalid(app, mocker):
 Error: u'description' is a required property
 Error: INVALID is not a valid license
 Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
-Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-preleases" instead.
+Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
 """
     else:
         expected = """\
 Error: 'description' is a required property
 Error: INVALID is not a valid license
 Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
-Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-preleases" instead.
+Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
 """
 
     assert expected == tester.io.fetch_output()


### PR DESCRIPTION
We stumbled upon some typos regarding the `allow-prereleases` option in the latest beta version. Here is a PR to fix those. :) 