### PR TITLE
Add Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+exemptProjects: true
+exemptMilestones: true
+
+closeComment: >
+  Closing this issue automatically because it has not had any activity since
+  it has been marked as stale. If you think it is still relevant and should
+  be addressed, feel free to open a new one.
+
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+
+  closeComment: >
+    Closing this pull request automatically because it has not had any activity since
+    it has been marked as stale. If you think it is still relevant and should
+    be addressed, feel free to open a new one.


### PR DESCRIPTION
This PR adds a Stale bot configuration.

Adding this bot will help us remove the clutter in issues and pull requests and have a fresh start as the `1.0` release is closing in.

Note that any issue that is tracked in a project and/or a milestone will never be marked as stale.
