### PR TITLE
don't require importlib-metadata with python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ keyring = [
 ]
 # Use subprocess32 for Python 2.7 and 3.4
 subprocess32 = { version = "^3.5", python = "~2.7 || ~3.4" }
-importlib-metadata = {version = "^0.23", python = "<=3.8"}
+importlib-metadata = {version = "^0.23", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.1"


### PR DESCRIPTION
This is probably only a typo.

`importlib-metadata` was included in the standard library with 3.8, so the requirement should be `< 3.8`, not `<= 3.8`.

Fixes: #1487 