### PR TITLE
Document change from `self:update` to `self update`

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -117,28 +117,28 @@ pipx uninstall poetry
 
 ## Updating `poetry`
 
-Updating poetry to the latest stable version is as simple as calling the `self:update` command.
+Updating Poetry to the latest stable version is as simple as calling the `self update` command.
 
 ```bash
-poetry self:update
+poetry self update
 ```
 
-If you want to install prerelease versions, you can use the `--preview` option.
+If you want to install pre-release versions, you can use the `--preview` option.
 
 ```bash
-poetry self:update --preview
+poetry self update --preview
 ```
 
-And finally, if you want to install a specific version you can pass it as an argument
-to `self:update`.
+And finally, if you want to install a specific version, you can pass it as an argument
+to `self update`.
 
 ```bash
-poetry self:update 0.8.0
+poetry self update 0.8.0
 ```
 
 !!!note
 
-    The `self:update` command will only work if you used the recommended
+    The `self update` command will only work if you used the recommended
     installer to install Poetry.
 
 


### PR DESCRIPTION
The _Updating Poetry_ section of the documentation says to run `poetry self:update`, but invoking `poetry self:update --preview` on Poetry 1.0.0b5 results in:

    The command "self:update" is not defined. 

Indeed, the output of `poetry self` shows that the correct syntax is:

    poetry self update [--preview] [<version>]

I confirmed that `poetry self update` behaves as expected. I assume the self-update syntax was changed at some point, but perhaps the documentation was not updated along with that code-level change.

This pull request adjusts the documentation to reflect the current Poetry self-update invocation.