### PR TITLE
CHANGE: simplified output by `poetry version`

### DIFF
--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -59,7 +59,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
             self.poetry.file.write(content)
         else:
             self.line(
-                "Project (<comment>{}</>) version is <info>{}</>".format(
+                "<comment>{}</> <info>{}</>".format(
                     self.poetry.package.name, self.poetry.package.pretty_version
                 )
             )

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -44,4 +44,4 @@ def test_version_show(app):
     command = app.find("version")
     tester = CommandTester(command)
     tester.execute()
-    assert "Project (simple-project) version is 1.2.3\n" == tester.io.fetch_output()
+    assert "simple-project 1.2.3\n" == tester.io.fetch_output()


### PR DESCRIPTION
This PR simplifies the output by `poetry` version to `<project_name> <version>` as suggest in #1590 .

This goes inline how most command line programs output the version and makes it easy to parse for downstream programs within a pipeline.


# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code. 
- [ ] Updated **documentation** for changed code.

