### PR TITLE
Improve the error message when the lock file is invalid

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -8,6 +8,7 @@ from tomlkit import document
 from tomlkit import inline_table
 from tomlkit import item
 from tomlkit import table
+from tomlkit.exceptions import TOMLKitError
 
 import poetry.packages
 import poetry.repositories
@@ -217,7 +218,10 @@ class Locker(object):
         if not self._lock.exists():
             raise RuntimeError("No lockfile found. Unable to read locked packages")
 
-        return self._lock.read()
+        try:
+            return self._lock.read()
+        except TOMLKitError as e:
+            raise RuntimeError("Unable to read the lock file ({}).".format(e))
 
     def _lock_packages(
         self, packages

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -181,3 +181,34 @@ A = []
         content = f.read()
 
     assert expected == content
+
+
+def test_reading_lock_file_should_raise_an_error_on_invalid_data(locker):
+    content = u"""[[package]]
+category = "main"
+description = ""
+name = "A"
+optional = false
+python-versions = "*"
+version = "1.0.0"
+
+[package.extras]
+foo = ["bar"]
+
+[package.extras]
+foo = ["bar"]
+
+[metadata]
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+python-versions = "*"
+
+[metadata.files]
+A = []
+"""
+    with locker.lock.open("w", encoding="utf-8") as f:
+        f.write(content)
+
+    with pytest.raises(RuntimeError) as e:
+        _ = locker.lock_data
+
+    assert "Unable to read the lock file" in str(e.value)


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR slightly improves the error message when the lock file is invalid. Instead of just raising the `tomlkit` error, which might be cryptic sometimes, we notify the user that the error occurred while reading the lock file.
