### PR TITLE
FIX: Regression of not excluding files from build

### DIFF
--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -2,9 +2,11 @@
 import re
 import shutil
 import tempfile
+
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Set, Union
+from typing import Set
+from typing import Union
 
 from clikit.api.io.flags import VERY_VERBOSE
 
@@ -13,9 +15,11 @@ from poetry.utils._compat import glob
 from poetry.utils._compat import lru_cache
 from poetry.utils._compat import to_str
 from poetry.vcs import get_vcs
+
 from ..metadata import Metadata
 from ..utils.module import Module
 from ..utils.package_include import PackageInclude
+
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
 

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -104,11 +104,14 @@ class Builder(object):
     def is_excluded(self, filepath):  # type: (Union[str, Path]) -> bool
         exclude_path = Path(filepath)
 
-        while exclude_path.as_posix() not in (".", "/"):
+        while True:
             if exclude_path.as_posix() in self.find_excluded_files():
                 return True
-            else:
+
+            if len(exclude_path.parts) > 1:
                 exclude_path = exclude_path.parent
+            else:
+                break
 
         return False
 

--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -115,9 +115,9 @@ class WheelBuilder(Builder):
                 return
 
             lib = lib[0]
-            excluded = self.find_excluded_files()
+
             for pkg in lib.glob("**/*"):
-                if pkg.is_dir() or pkg in excluded:
+                if pkg.is_dir() or self.is_excluded(pkg):
                     continue
 
                 rel_path = str(pkg.relative_to(lib))
@@ -132,7 +132,7 @@ class WheelBuilder(Builder):
                 self._add_file(wheel, pkg, rel_path)
 
     def _copy_module(self, wheel):
-        excluded = self.find_excluded_files()
+
         to_add = []
 
         for include in self._module.includes:
@@ -153,7 +153,7 @@ class WheelBuilder(Builder):
                 else:
                     rel_file = file.relative_to(self._path)
 
-                if rel_file.as_posix() in excluded:
+                if self.is_excluded(rel_file.as_posix()):
                     continue
 
                 if file.suffix == ".pyc":

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -207,7 +207,7 @@ class Git:
         args += ["ls-files", "--others", "-i", "--exclude-standard"]
         output = self.run(*args)
 
-        return output.split("\n")
+        return output.strip().split("\n")
 
     def remote_urls(self, folder=None):  # type: (...) -> dict
         output = self.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ pre-commit = "^1.10"
 tox = "^3.0"
 pytest-sugar = "^0.9.2"
 httpretty = "^0.9.6"
-isort = "^4.3.21"
 
 [tool.poetry.scripts]
 poetry = "poetry.console:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ pre-commit = "^1.10"
 tox = "^3.0"
 pytest-sugar = "^0.9.2"
 httpretty = "^0.9.6"
+isort = "^4.3.21"
 
 [tool.poetry.scripts]
 poetry = "poetry.console:main"

--- a/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 readme = "README.rst"
 
-exclude = ["my_package/data/", "**/*/item*"]
+exclude = ["**/data/", "**/*/item*"]
 
 homepage = "https://poetry.eustace.io/"
 repository = "https://github.com/sdispater/poetry"


### PR DESCRIPTION
This PR changes the way, how it is checked if a file should be excluded from build.

Fixes: #1597 


# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

