### PR TITLE
Make index urls a set to avoid exporting duplicates to requirements.txt

### DIFF
--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -54,7 +54,7 @@ class Exporter(object):
         extras=None,
         with_credentials=False,
     ):  # type: (Path, Union[IO, str], bool, bool, bool) -> None
-        indexes = []
+        indexes = set()
         content = ""
         packages = self._poetry.locker.locked_repository(dev).packages
 
@@ -108,7 +108,7 @@ class Exporter(object):
                 package.source_type not in {"git", "directory", "file", "url"}
                 and package.source_url
             ):
-                indexes.append(package.source_url)
+                indexes.add(package.source_url)
 
             if package.files and with_hashes:
                 hashes = []

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -134,10 +134,9 @@ class Exporter(object):
             content += line
 
         if indexes:
-            # If we have extra indexes, we add them to the begin
-            # of the output
+            # If we have extra indexes, we add them to the beginning of the output
             indexes_header = ""
-            for index in indexes:
+            for index in sorted(indexes):
                 repository = [
                     r
                     for r in self._poetry.pool.repositories

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -707,7 +707,9 @@ foo==1.2.3 \\
     assert expected == content
 
 
-def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_sources(tmp_dir, poetry):
+def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_sources(
+    tmp_dir, poetry
+):
     poetry.pool.add_repository(
         LegacyRepository(
             "custom",

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -717,6 +717,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_so
             auth=Auth("https://example.com/simple", "foo", "bar"),
         )
     )
+    poetry.pool.add_repository(LegacyRepository("custom", "https://foobaz.com/simple",))
     poetry.locker.mock_lock_data(
         {
             "package": [
@@ -744,11 +745,23 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_so
                         "reference": "",
                     },
                 },
+                {
+                    "name": "baz",
+                    "version": "7.8.9",
+                    "category": "dev",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://foobaz.com/simple",
+                        "reference": "",
+                    },
+                },
             ],
             "metadata": {
                 "python-versions": "*",
                 "content-hash": "123456789",
-                "hashes": {"foo": ["12345"], "bar": ["67890"]},
+                "hashes": {"foo": ["12345"], "bar": ["67890"], "baz": ["24680"]},
             },
         }
     )
@@ -761,9 +774,12 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_so
 
     expected = """\
 --extra-index-url https://example.com/simple
+--extra-index-url https://foobaz.com/simple
 
 bar==4.5.6 \\
     --hash=sha256:67890
+baz==7.8.9 \\
+    --hash=sha256:24680
 foo==1.2.3 \\
     --hash=sha256:12345
 """

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -707,6 +707,68 @@ foo==1.2.3 \\
     assert expected == content
 
 
+def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_sources(tmp_dir, poetry):
+    poetry.pool.add_repository(
+        LegacyRepository(
+            "custom",
+            "https://example.com/simple",
+            auth=Auth("https://example.com/simple", "foo", "bar"),
+        )
+    )
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example.com/simple",
+                        "reference": "",
+                    },
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "dev",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example.com/simple",
+                        "reference": "",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": ["12345"], "bar": ["67890"]},
+            },
+        }
+    )
+    exporter = Exporter(poetry)
+
+    exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt", dev=True)
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+--extra-index-url https://example.com/simple
+
+bar==4.5.6 \\
+    --hash=sha256:67890
+foo==1.2.3 \\
+    --hash=sha256:12345
+"""
+
+    assert expected == content
+
+
 def test_exporter_exports_requirements_txt_with_legacy_packages_and_credentials(
     tmp_dir, poetry, config
 ):


### PR DESCRIPTION
Fixes #1434

As sources are included per package in the lock data, this fix allows `--extra-index-url` to be specified only once in the exported `requirements.txt`

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
