### PR TITLE
fixes issue where exporting to requirements.txt always prepends -e to dependencies

### DIFF
--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -63,6 +63,7 @@ class Dependency(object):
 
         self.is_root = False
         self.marker = AnyMarker()
+        self._develop = False
 
     @property
     def name(self):
@@ -154,6 +155,10 @@ class Dependency(object):
             requirement += " ({})".format(str(self.constraint).replace(" ", ""))
 
         return requirement
+
+    @property
+    def develop(self):  # type: () -> bool
+        return self._develop
 
     def allows_prereleases(self):
         return self._allows_prereleases

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -94,7 +94,7 @@ class Exporter(object):
                 dependency.marker = package.marker
 
                 line = "{}".format(package.source_url)
-                if package.develop:
+                if dependency.develop:
                     line = "-e " + line
             else:
                 dependency = package.to_dependency()


### PR DESCRIPTION
fixes issue where exporting to requirements.txt always prepends -e to dependencies even if they're not directory dependencies that are installed as editable.

I am not fully educated on the difference between a "Package" and a "Dependency" in `poetry`-parlance, but looking at the way that "Package" _always_ defines `develop = True` by default, and the way the source code in `packages/package.py` provides the `develop` constraint only to `DirectoryDependency`, it seems likely to me that the intent within the requirements.txt `exporter.py` was to use the `dependency.develop` check rather than the `package.develop` check.

In any case, this fixes the issue where my dependencies were being exported as `-e ` (editable) despite being file dependencies rather than editable directory dependencies. It should _also_ fix https://github.com/sdispater/poetry/issues/1451, because now that `develop=false` constraint, which is getting properly added to the Dependency object (but is never added to the Package object) will be used at export time.

