### PR TITLE
Bugfix: Empty and Any markers saved to lockfile

### DIFF
--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -633,7 +633,7 @@ class MarkerUnion(BaseMarker):
         )
 
     def is_any(self):
-        return all(m.is_any() for m in self._markers)
+        return any(m.is_any() for m in self._markers)
 
     def is_empty(self):
         return all(m.is_empty() for m in self._markers)

--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -628,7 +628,15 @@ class MarkerUnion(BaseMarker):
         return h
 
     def __str__(self):
-        return " or ".join(str(m) for m in self._markers)
+        return " or ".join(
+            str(m) for m in self._markers if not m.is_any() and not m.is_empty()
+        )
+
+    def is_any(self):
+        return all(m.is_any() for m in self._markers)
+
+    def is_empty(self):
+        return all(m.is_empty() for m in self._markers)
 
 
 def parse_marker(marker):

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -354,6 +354,46 @@ def test_marker_union_union_duplicates():
     )
 
 
+def test_marker_union_all_any():
+    union = MarkerUnion(parse_marker(""), parse_marker(""))
+
+    assert union.is_any()
+
+
+def test_marker_union_not_all_any():
+    union = MarkerUnion(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
+
+    assert not union.is_any()
+
+
+def test_marker_union_all_empty():
+    union = MarkerUnion(parse_marker("<empty>"), parse_marker("<empty>"))
+
+    assert union.is_empty()
+
+
+def test_marker_union_not_all_empty():
+    union = MarkerUnion(
+        parse_marker("<empty>"), parse_marker("<empty>"), parse_marker("")
+    )
+
+    assert not union.is_empty()
+
+
+def test_marker_str_conversion_skips_empty_and_any():
+    union = MarkerUnion(
+        parse_marker("<empty>"),
+        parse_marker(
+            'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
+        ),
+        parse_marker(""),
+    )
+
+    assert str(union) == (
+        'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
+    )
+
+
 def test_intersect_compacts_constraints():
     m = parse_marker('python_version < "4.0"')
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -363,7 +363,7 @@ def test_marker_union_all_any():
 def test_marker_union_not_all_any():
     union = MarkerUnion(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
 
-    assert not union.is_any()
+    assert union.is_any()
 
 
 def test_marker_union_all_empty():


### PR DESCRIPTION
When locking some private packages of ours (that have extras) it used to copy those extras over in `1.0.0b3` when we changed that behaviour it's now the `Any` marker and when it stringifies that when generating the lockfile it creates a format the lockfile doesn't support.

**bugfix**: Originally, the `MarkerUnion` didn't correctly respond to `is_any` or `is_empty` because it didn't evaluate the collection of markers which led to it trying to stringify those markers.

This on conjunction with the other fix means that the `[Any, Any]` case is simply excluded from the lockfile just like a single Any case.

**bugfix**
Before:
`' or '.join([Any, Any])` -> `' or '`
`' or '.join([Any, REAL MARKER])` -> `' or REAL MARKER'`
`' or '.join([Empty, Empty])` -> `'<empty> or <empty>'`

Now
`' or '.join([Any, Any])` -> `''`
`' or '.join([Any, REAL MARKER])` -> `'REAL MARKER'`
`' or '.join([Empty, Empty])` -> `''`

This means if we have a mix of markers with any/empty that won't be propagated to the lockfile.
