### PR TITLE
fix (#1654): exporting to requirements.txt always prepends -e to dependencies

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -146,7 +146,6 @@ class Locker(object):
                 package.source_url = info["source"]["url"]
                 package.source_reference = info["source"]["reference"]
 
-
             packages.add_package(package)
 
         return packages

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -143,6 +143,9 @@ class Locker(object):
                 package.source_url = info["source"]["url"]
                 package.source_reference = info["source"]["reference"]
 
+                if "develop" in info["source"]:
+                    package.develop = info["source"]["develop"]
+
             packages.add_package(package)
 
         return packages
@@ -301,5 +304,7 @@ class Locker(object):
             }
             if package.source_type:
                 data["source"]["type"] = package.source_type
+            if package.source_type == "directory":
+                data["source"]["develop"] = package.develop
 
         return data

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -138,13 +138,14 @@ class Locker(object):
 
                 package.add_dependency(dep_name, constraint)
 
+            if "develop" in info:
+                package.develop = info["develop"]
+
             if "source" in info:
                 package.source_type = info["source"].get("type", "")
                 package.source_url = info["source"]["url"]
                 package.source_reference = info["source"]["reference"]
 
-                if "develop" in info["source"]:
-                    package.develop = info["source"]["develop"]
 
             packages.add_package(package)
 
@@ -305,6 +306,6 @@ class Locker(object):
             if package.source_type:
                 data["source"]["type"] = package.source_type
             if package.source_type == "directory":
-                data["source"]["develop"] = package.develop
+                data["develop"] = package.develop
 
         return data

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -275,6 +275,7 @@ class Provider:
         )
 
         package.source_url = dependency.path.as_posix()
+        package.develop = dependency.develop
 
         if dependency.base is not None:
             package.root_dir = dependency.base.as_posix()

--- a/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
@@ -11,6 +11,7 @@ extras_a = ["pendulum (>=1.4.4)"]
 extras_b = ["cachy (>=0.2.0)"]
 
 [package.source]
+develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_directory_dependencies/../../project_with_extras"
@@ -27,6 +28,7 @@ version = "1.2.3"
 project-with-extras = "*"
 
 [package.source]
+develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_directory_dependencies"

--- a/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
@@ -1,6 +1,7 @@
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "project-with-extras"
 optional = false
 python-versions = "*"
@@ -11,7 +12,6 @@ extras_a = ["pendulum (>=1.4.4)"]
 extras_b = ["cachy (>=0.2.0)"]
 
 [package.source]
-develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_directory_dependencies/../../project_with_extras"
@@ -19,6 +19,7 @@ url = "tests/fixtures/directory/project_with_transitive_directory_dependencies/.
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "project-with-transitive-directory-dependencies"
 optional = false
 python-versions = "*"
@@ -28,7 +29,6 @@ version = "1.2.3"
 project-with-extras = "*"
 
 [package.source]
-develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_directory_dependencies"

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -9,6 +9,7 @@ version = "1.4.4"
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "project-with-extras"
 optional = false
 python-versions = "*"
@@ -22,7 +23,6 @@ extras_a = ["pendulum (>=1.4.4)"]
 extras_b = ["cachy (>=0.2.0)"]
 
 [package.source]
-develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/project_with_extras"

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -22,6 +22,7 @@ extras_a = ["pendulum (>=1.4.4)"]
 extras_b = ["cachy (>=0.2.0)"]
 
 [package.source]
+develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/project_with_extras"

--- a/tests/installation/fixtures/with-directory-dependency-setuptools.test
+++ b/tests/installation/fixtures/with-directory-dependency-setuptools.test
@@ -15,6 +15,7 @@ optional = false
 python-versions = "*"
 
 [package.source]
+develop = true
 type = "directory"
 reference = ""
 url = "tests/fixtures/project_with_setup"

--- a/tests/installation/fixtures/with-directory-dependency-setuptools.test
+++ b/tests/installation/fixtures/with-directory-dependency-setuptools.test
@@ -9,13 +9,13 @@ python-versions = "*"
 [[package]]
 name = "my-package"
 version = "0.1.2"
+develop = true
 description = "Demo project."
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.source]
-develop = true
 type = "directory"
 reference = ""
 url = "tests/fixtures/project_with_setup"

--- a/tests/installation/fixtures/with-file-dependency-transitive.test
+++ b/tests/installation/fixtures/with-file-dependency-transitive.test
@@ -38,6 +38,7 @@ version = "1.2.3"
 demo = "*"
 
 [package.source]
+develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_file_dependencies"

--- a/tests/installation/fixtures/with-file-dependency-transitive.test
+++ b/tests/installation/fixtures/with-file-dependency-transitive.test
@@ -29,6 +29,7 @@ version = "1.4.4"
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "project-with-transitive-file-dependencies"
 optional = false
 python-versions = "*"
@@ -38,7 +39,6 @@ version = "1.2.3"
 demo = "*"
 
 [package.source]
-develop = true
 reference = ""
 type = "directory"
 url = "tests/fixtures/directory/project_with_transitive_file_dependencies"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -25,6 +25,9 @@ from tests.repositories.test_legacy_repository import (
 from tests.repositories.test_pypi_repository import MockRepository
 
 
+fixtures_dir = Path("tests/fixtures")
+
+
 class Installer(BaseInstaller):
     def _get_installer(self):
         return NoopInstaller()
@@ -662,7 +665,7 @@ def test_installer_with_pypi_repository(package, locker, installed):
 
 
 def test_run_installs_with_local_file(installer, locker, repo, package):
-    file_path = Path("tests/fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl")
+    file_path = fixtures_dir / "distributions/demo-0.1.0-py2.py3-none-any.whl"
     package.add_dependency("demo", {"file": str(file_path)})
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -677,8 +680,8 @@ def test_run_installs_with_local_file(installer, locker, repo, package):
 
 
 def test_run_installs_wheel_with_no_requires_dist(installer, locker, repo, package):
-    file_path = Path(
-        "tests/fixtures/wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
+    file_path = (
+        fixtures_dir / "wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
     )
     package.add_dependency("demo", {"file": str(file_path)})
 
@@ -694,7 +697,7 @@ def test_run_installs_wheel_with_no_requires_dist(installer, locker, repo, packa
 def test_run_installs_with_local_poetry_directory_and_extras(
     installer, locker, repo, package, tmpdir
 ):
-    file_path = Path("tests/fixtures/project_with_extras")
+    file_path = fixtures_dir / "project_with_extras"
     package.add_dependency(
         "project-with-extras", {"path": str(file_path), "extras": ["extras_a"]}
     )
@@ -713,8 +716,8 @@ def test_run_installs_with_local_poetry_directory_and_extras(
 def test_run_installs_with_local_poetry_directory_transitive(
     installer, locker, repo, package, tmpdir
 ):
-    file_path = Path(
-        "tests/fixtures/directory/project_with_transitive_directory_dependencies/"
+    file_path = (
+        fixtures_dir / "directory/project_with_transitive_directory_dependencies/"
     )
     package.add_dependency(
         "project-with-transitive-directory-dependencies", {"path": str(file_path)}
@@ -735,9 +738,7 @@ def test_run_installs_with_local_poetry_directory_transitive(
 def test_run_installs_with_local_poetry_file_transitive(
     installer, locker, repo, package, tmpdir
 ):
-    file_path = Path(
-        "tests/fixtures/directory/project_with_transitive_file_dependencies/"
-    )
+    file_path = fixtures_dir / "directory/project_with_transitive_file_dependencies/"
     package.add_dependency(
         "project-with-transitive-file-dependencies", {"path": str(file_path)}
     )
@@ -757,7 +758,7 @@ def test_run_installs_with_local_poetry_file_transitive(
 def test_run_installs_with_local_setuptools_directory(
     installer, locker, repo, package, tmpdir
 ):
-    file_path = Path("tests/fixtures/project_with_setup/")
+    file_path = fixtures_dir / "project_with_setup/"
     package.add_dependency("my-package", {"path": str(file_path)})
 
     repo.add_package(get_package("pendulum", "1.4.4"))


### PR DESCRIPTION
This PR fixes (at least partially) #1654.

It now respects the `develop` value set in `pyproject.toml` when exporting to `requirements.txt` and also installing in non-development mode works again.


# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
